### PR TITLE
Issue #3 - better setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,24 @@ and the client can build its UI dynamically from `/capabilities`.
 
 ## Quickstart
 
-Each server is a standalone script. Install the engine package plus the
-shared bits, then run:
+The servers in `impl/` are standalone scripts built on the shared
+`tts-engine-common` package — both live in this repo, so start from a clone:
 
 ```bash
+git clone https://github.com/scorbo2/tts-serve && cd tts-serve
+pip install ./tts-engine-common
 pip install chatterbox-tts fastapi uvicorn loguru soundfile
-pip install tts-engine-common   # or: pip install -e ./tts-engine-common
 python impl/server_chatterbox.py
 ```
 
 (Replace `chatterbox-tts` with `omnivoice`, `qwen-tts`, or `dots.tts` and
 `server_chatterbox.py` with the matching file for the other engines. On first
 start the model weights download from HuggingFace.)
+
+The install commands assume an active virtual environment (e.g.
+`python3 -m venv .venv && source .venv/bin/activate`), or your existing
+conda setup. If you run more than one engine, give each one its own
+environment — their dependency trees will conflict.
 
 Then talk to it:
 

--- a/impl/README.md
+++ b/impl/README.md
@@ -24,7 +24,7 @@ All servers also take `*_HOST` (default `0.0.0.0`) and `*_PORT`
 
 ```bash
 pip install <engine-package> fastapi uvicorn loguru soundfile
-pip install tts-engine-common        # or: pip install -e ../tts-engine-common
+pip install ../tts-engine-common     # in-repo copy; or: pip install -e ../tts-engine-common
 python server_chatterbox.py          # or: uvicorn server_chatterbox:app
 ```
 

--- a/impl/server_chatterbox.py
+++ b/impl/server_chatterbox.py
@@ -31,7 +31,7 @@ Configuration (environment variables):
 
 Extra dependencies beyond the chatterbox-tts package:
     pip install fastapi uvicorn loguru soundfile
-    pip install tts-engine-common    # or: pip install -e ../tts-engine-common
+    pip install ../tts-engine-common # in-repo copy; or: pip install -e ../tts-engine-common
 
 Usage:
     python server_chatterbox.py

--- a/impl/server_dotsTTS.py
+++ b/impl/server_dotsTTS.py
@@ -28,7 +28,7 @@ Configuration (environment variables):
 
 Extra dependencies beyond the dots.tts package:
     pip install fastapi uvicorn loguru soundfile
-    pip install tts-engine-common    # or: pip install -e ../tts-engine-common
+    pip install ../tts-engine-common # in-repo copy; or: pip install -e ../tts-engine-common
 
 Usage:
     python server_dotsTTS.py

--- a/impl/server_omnivoice.py
+++ b/impl/server_omnivoice.py
@@ -27,7 +27,7 @@ Configuration (environment variables):
 
 Extra dependencies beyond the omnivoice package:
     pip install fastapi uvicorn loguru soundfile
-    pip install tts-engine-common    # or: pip install -e ../tts-engine-common
+    pip install ../tts-engine-common # in-repo copy; or: pip install -e ../tts-engine-common
 
 Usage:
     python server_omnivoice.py

--- a/impl/server_qwen3TTS.py
+++ b/impl/server_qwen3TTS.py
@@ -28,7 +28,7 @@ Configuration (environment variables):
 
 Extra dependencies beyond the qwen-tts package:
     pip install fastapi uvicorn loguru soundfile
-    pip install tts-engine-common    # or: pip install -e ../tts-engine-common
+    pip install ../tts-engine-common # in-repo copy; or: pip install -e ../tts-engine-common
 
 Usage:
     python server_qwen3TTS.py


### PR DESCRIPTION
This PR addresses issue #3 by clarifying the setup/installation instructions. Removed the reference to PyPI and explicitly mention git clone as a necessary first step. Make sure to mention setting up a venv/conda environment (most users will know to do this but include it anyway).