### PR TITLE
Issue #5 - port the old speak script to this repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Commands (run from repo root)
 
 - Full test suite (no torch, GPU, or engine packages needed — verified on a bare dev box):
-  `python -m pytest tts-engine-common/tests/ impl/tests/`
+  `python -m pytest tts-engine-common/tests/ impl/tests/ tools/tests/`
 - Single test: plain pytest, e.g. `python -m pytest impl/tests/test_server_omnivoice.py -k seed`
 - After changing a server's request schema or engine constants, regenerate snapshots and review the diff:
   `python impl/tests/update_snapshots.py`
@@ -16,6 +16,7 @@
 - `tts-engine-common/` — shared FastAPI + Pydantic package. Design constraint: **no torch, no engine deps** — it must stay importable and testable on any box (see `pyproject.toml` comment and `docs/01-server-generification.md` D7).
 - `impl/` — four standalone FastAPI server scripts, one per engine: `server_chatterbox.py`, `server_omnivoice.py`, `server_qwen3TTS.py`, `server_dotsTTS.py`. Run via `python impl/server_<name>.py` or uvicorn; env config is documented in each module's docstring.
 - `impl/tests/` — GPU-free test suite + committed `/capabilities` snapshots (`snapshots/`).
+- `tools/` — `speak.py`, a command-line testing tool for any engine server: stdlib-only (no torch, no engine deps, no need to install `tts-engine-common`), discovers engine parameters from `GET /capabilities`. GPU-free tests in `tools/tests/` (network and aplay stubbed). Spec: `docs/03-speak-script.md`.
 - `docs/` — design docs; `01-server-generification.md` contains the binding decisions (D1–D7).
 
 ## Architecture facts that change how you work

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ python impl/tests/update_snapshots.py
 ## Testing
 
 In addition to a full suite of unit tests, manual testing is possible via
-REST calls using `curl` or some Postman-like took against a running `tts-serve` instance:
+REST calls using `curl` or some Postman-like tool against a running `tts-serve` instance:
 
 ```
 curl http://localhost:8000/health # shows basic server information including server type

--- a/README.md
+++ b/README.md
@@ -116,7 +116,32 @@ python -m pytest tts-engine-common/tests/ impl/tests/
 python impl/tests/update_snapshots.py
 ```
 
+## Testing
+
+In addition to a full suite of unit tests, manual testing is possible via
+REST calls using `curl` or some Postman-like took against a running `tts-serve` instance:
+
+```
+curl http://localhost:8000/health # shows basic server information including server type
+curl http://localhost:8000/capabilities # full capabilities list in Json format
+```
+
+Actual speech generation is better handled via the `speak.py` script,
+available in the `tools` directory:
+
+```
+python3 speak.py -h # show general help
+python3 speak-py --server http://localhost:8000 --list-server-params # inspect capabilities
+```
+
 ## Documentation
 
-- [`docs/00-project-overview.md`](docs/00-project-overview.md) — goals and the common vocabulary
+This project is built with spec-driven development. The human comes up with a detailed spec,
+and the LLM (Qwen 3.8 27B mostly) does the actual implementation. The specs are stored here
+for archeological purposes - the code is always the ultimate source of truth, and may drift
+over time from these original documents.
+
+- [`docs/00-project-overview.md`](docs/00-project-overview.md) — project goals and the common vocabulary
 - [`docs/01-server-generification.md`](docs/01-server-generification.md) — `/capabilities` design and open questions
+- [`docs/02-language-handling.md`](docs/02-language-handling.md) — Amendments to `language` parameter handling
+- [`docs/03-speak-script.md`](docs/03-speak-script.md) — addition of a handy command-line testing tool

--- a/docs/03-speak-script.md
+++ b/docs/03-speak-script.md
@@ -1,0 +1,222 @@
+# Speak script (command-line testing tool)
+
+The project should include a `speak.py` script for testing purposes,
+similar to the old `ai-playground/TTS` repo, but updated for use with
+any of the impl scripts in `tts-serve`.
+
+## Current state
+
+This project replaced the older TTS server scripts in `ai-playground`.
+The `speak.py` script from that repo was not ported to this repo
+during development.
+
+## Proposed state
+
+Create a new `tools` directory in `tts-serve`. Its contents
+will be a script `speak.py`, based loosely on the original `speak.py`,
+and tests for this script (capabilities-parser mapping, payload assembly,
+persona-dir resolution, base64 handling, reference text whitespace collapsing, etc).
+
+The original script assumed a hard-coded "lowest common denominator"
+set of input parameters. The new script will interrogate the user-supplied
+server via `GET /capabilities` to determine the list of required and
+optional input parameters.
+
+The script uses only Python standard library dependencies (urllib/json/argparse/etc), 
+so it should run on any client machine, even without tts-engine-common installed.
+
+### Old speak.py usage
+
+```
+$ speak.py -h
+usage: speak.py [-h] [--language LANGUAGE] [--server SERVER] [--ref-audio REF_AUDIO]
+                [--ref-audio-transcript REF_AUDIO_TRANSCRIPT] [--seed SEED] [--steps [1-30]]
+                [--output-file OUTPUT_FILE]
+                text
+
+Synthesize speech using the dots.tts REST API.
+
+positional arguments:
+  text                  Text string to synthesize
+
+options:
+  -h, --help            show this help message and exit
+  --language LANGUAGE   Language code (default: en)
+  --server SERVER       API server URL
+  --ref-audio REF_AUDIO
+                        Path to reference audio WAV file
+  --ref-audio-transcript REF_AUDIO_TRANSCRIPT
+                        Path to reference transcript text file
+  --seed SEED           Random seed for generation (default: null)
+  --steps [1-30]        Number of generation steps (default: 12)
+  --output-file OUTPUT_FILE
+                        Path to save output WAV. If empty, plays via aplay and discards
+
+Examples:
+  # Use all defaults (backward compatible with speak.sh)
+  speak.py "Hello, how are you?"
+
+  # Custom language, steps, and save to file
+  speak.py "Bonjour le monde" --language fr --steps 20 --output-file greeting.wav
+
+  # Override reference files and server
+  speak.py "Test" --ref-audio my_voice.wav --ref-audio-transcript my_voice.txt --server http://localhost:8000/tts
+```
+
+### Proposed new usage
+
+Use `argparse` for command-line argument handling.
+
+The new script's only known-in-advance parameters (`parse_known_args()`):
+
+- `--server`: (required! no default) The server URL (example: `http://10.0.0.5:8000`)
+  **Note**: the old script required the full URL, with endpoint (example: `http://10.0.0.5:8000/synthesize`).
+  This new script requires just the server name/IP and port. The endpoint is discovered from `/capabilities`.
+- `text` (required positional argument): any text to be synthesized.
+  Not needed when `--list-server-params` is given (the listing performs no synthesis).
+- `--ref-audio`: (optional) any audio file (voice cloning reference audio)
+- `--ref-audio-transcript`: (optional) any text file (voice cloning reference transcript)
+- `--persona-dir` (optional): see Persona Directory section.
+- `--output-file` (optional): see Output section.
+- `--timeout` (optional, default 120): request timeout in seconds. Must be a
+  positive integer; zero or negative values are rejected at parse time (exit 2).
+- `--list-server-params` (optional flag): fetch `/capabilities`, print a
+  formatted summary (engine metadata plus the flags this script will expose
+  for the engine's parameters, with defaults, choices, and ranges), and exit
+  0. Needs no `text` and no reference audio; nothing is synthesized. The
+  reserved-name and file-driven conventions above are reflected in the output.
+
+These should be parsed first to ensure that they are present. Additional arguments should **not**
+be parsed at this time, because the script does not yet know if they are valid.
+
+The script must query `{server}/capabilities` endpoint and parse the returned Json.
+If the server can't be reached, returns any non-2xx code, or does not return a valid
+Json *object*, log error and exit with status 1. (Valid JSON that is not an object —
+an array or a bare string — is an unknown document shape and must produce the same
+clean error, never a traceback.) Check the schema version in the return! If the script
+is connecting to a server with an unknown (future) version, log error and exit with
+status 1: "Server returned unknown schema version {returnedVersion}, expected {currentVersion}; aborting."
+
+Based on the returned Json document, the script can then use `add_argument()` as needed
+for each parameter. This `add_argument()` loop must skip `text`, `audio_base64`, and
+`reference_text` to avoid polluting the `-h` help text output.
+
+Now, use strict `parse_args()` (not `parse_known_args()`) to check the remaining supplied arguments.
+Any unrecognized/unexpected argument can trigger an `Unrecognized argument: ...` error
+and exit status 2. Type checking comes for free with `argparse`. If a given parameter
+is marked as numeric by the server, and the user has supplied a string like "test":
+`invalid int value: 'test'`. Required enforcement is also free: if an argument is required
+and the user omitted it: `the following arguments are required: ...` and exit status 2.
+
+The two-stage argparse requires that `parse_known_args()` extend the **same** parser object,
+since the final strict `parse_args()` re-parses the entire command line.
+
+**Enum handling note**: Enum options returned from the server should be handled as argparse choices.
+This gives us "invalid choice" for free.
+**Gotcha**: the capabilities document carries enum values as *strings*, and argparse
+checks `choices` *after* applying the flag's type — so the values must be coerced
+through the parameter's type (an integer enum `["1", "2"]` must become choices
+`[1, 2]`), or a numeric enum can never match the value the user typed.
+
+**Range handling note**: The script is NOT responsible for handling min/max validation. The
+server can already handle that and return a meaningful error for invalid values. Let the server
+be the source of truth for min/max value handling instead of inventing our own range validators.
+
+**Boolean handling note**: the script should use a string-to-bool function for boolean arguments
+(explicit checks for "true", "yes", "1", "on", "false", "no", "0", "off") to avoid problems
+with argparse's default handling of "any non-empty string is true".
+
+The script should build the payload only from the arguments the user actually specified,
+instead of filling them in with their default values. For example, if the user omits
+the `seed` argument (optional, with `default: null`), it is better to omit it from
+the payload rather than specify it with its default value.
+
+**Kebab-case versus snake-case**: All underscores in server parameters should be
+replaced with `-` to maintain the kebab-style argument convention. For example,
+the `num_steps` argument should be given to this script as `--num-steps`, not `--num_steps`.
+
+If the server returns a parameter whose name conflicts with one of the script's
+reserved argument names, that server parameter should be ignored with a warning.
+For example, if the server specifies a parameter named `output_file`, that would
+conflict with this script's `--output-file` argument. Log warning "Server returned
+a reserved parameter name output_file; ignoring it." and continue. The reserved set
+also includes argparse's built-in `help`, since a parameter named `help` would
+otherwise crash argparse with "conflicting option string".
+
+The computed payload should be POSTed to `{server}/{endpoint}` using the server's
+advertised endpoint (do not hard-code `/synthesize`). Normalize trailing slashes
+on `{server}`. Any non-2xx return code: log error including the return code, and
+exit with status 1.
+
+The return body must be valid Json, and must contain a non-empty `audio_base64` field.
+Otherwise, exit with status 1 and error "Invalid response from server."
+
+### Handling reference audio and reference transcripts
+
+All `tts-serve` implementation scripts expect `audio_base64`, but there is no `--audio-base64`
+argument. Instead, the script should accept `--ref-audio` pointing to any audio file, and handle
+the base64 encoding on behalf of the user. This matches the behavior of the old script.
+
+Any `tts-serve` implementation script that requires a transcript of the reference audio
+will expect `reference_text`, but there is no `--reference-text` argument. Instead, the script
+should accept `--ref-audio-transcript` pointing to any text file, and handle loading text
+from that file (collapsing contents with `" ".join(raw.split())`). 
+This matches the behavior of the old script.
+
+Both `--ref-audio` and `--ref-audio-transcript` are superseded by `--persona-dir` if present.
+
+It is never an error to specify `--ref-audio-transcript`, even for `tts-serve` implementations
+that do not ask for reference text (Chatterbox, for example). The script can simply ignore
+the supplied reference text with a warning ("Reference text ignored as this server does not accept it").
+
+It is always an error to omit `--ref-audio` (or `--persona-dir`, if `--ref-audio` is not specified).
+ALL tts-serve implementation scripts require `audio_base64`. So, even though both `--ref-audio`
+and `--persona-dir` are marked as optional arguments, at least one of them must be specified!
+Exit with status 1 and message "You must supply reference audio or a persona directory!"
+
+## Persona Directory
+
+Instead of `--ref-audio` and `--ref-audio-transcript`, the user can supply `--persona-dir`,
+pointing to any directory. This directory should contain `ref.wav` representing the reference
+audio, and `ref.txt` representing the reference transcript. It is an error if either file is missing,
+or if the given directory does not exist or can't be read.
+
+If both `--ref-audio` and `--persona-dir` are given, `--ref-audio` is ignored with a warning.
+
+If both `--ref-audio-transcript` and `--persona-dir` are given, `--ref-audio-transcript` is
+ignored with a warning.
+
+## Output
+
+If `--output-file` is specified, the returned audio is base64-decoded and written
+to the specified output file, with a `[y/N]` overwrite confirmation prompt if the
+specified file already exists. If stdin is EOF (piped, non-interactive), "N" is
+assumed. If "N" is selected, the output is silently discarded. This is not an error.
+
+If `--output-file` is not specified, the returned audio is base64-decoded and
+given to `aplay` for immediate output. If `aplay` is not installed, log error
+and exit with status 1. If `aplay` returns a non-zero exit code, log warning and
+continue.
+
+Note that `--output-file` is an implied "silent" option - the script EITHER
+saves the returned audio to a file OR outputs it to `aplay`, never both.
+
+All `tts-serve` implementation scripts return `seed`, `time_used`, and `rtf`. These should
+be logged regardless of the output destination of the audio. Log this before attempting
+to play/save the audio! Otherwise, it may get skipped if audio output or save fails.
+
+## Logging
+
+Normal logging and warnings to stdout, errors to stderr. User can redirect as needed.
+
+## Script exit codes
+
+- 0: normal termination
+- 1: catch-all error code
+- 2: argparse error code
+
+## Tests
+
+`AGENTS.md` in this repo requires a full `python -m pytest tts-engine-common/tests impl/tests`
+after every code change, to ensure all tests are green. That instruction should be updated to
+include the tests for this script in the new `tools` directory.

--- a/tools/speak.py
+++ b/tools/speak.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""speak.py — command-line testing tool for tts-serve engine servers.
+
+Synthesizes speech by POSTing to any tts-serve implementation.  The tunable
+parameters are not hard-coded: the script first queries ``GET {server}/capabilities``,
+builds the rest of its CLI from the returned document, and only then validates
+the user's remaining arguments.  This is the client-side half of design
+decision D4 (docs/01-server-generification.md): the server's request model is
+the single source of truth, so the CLI can never drift from it.
+
+Usage:
+    python tools/speak.py "Hello, world" --server http://10.0.0.5:8000 --ref-audio my_voice.wav
+    python tools/speak.py "Bonjour le monde" --server http://10.0.0.5:8000 \
+        --persona-dir ./alice --language fr --output-file greeting.wav
+    python tools/speak.py --server http://10.0.0.5:8000 --list-server-params
+
+Standard library only, on purpose: this must run on any client box, even
+without tts-engine-common (or torch) installed.
+
+Full behavioral spec: docs/03-speak-script.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import urllib.error
+import urllib.request
+
+# Kept in sync with tts-engine-common's SCHEMA_VERSION.  This script must not
+# import tts-engine-common (stdlib-only), so the constant is deliberately
+# duplicated here: a mismatch against a future server is a loud, deliberate
+# failure, not a silent misparse of an unknown document shape.
+SUPPORTED_SCHEMA_VERSION = 2
+
+# Request fields handled by dedicated CLI machinery (positional / file-backed),
+# so they are never exposed as dynamic arguments.  The values name the CLI
+# surface that supplies each field (used by --list-server-params).
+_FILE_DRIVEN_PROVIDERS = {
+    "text": "positional 'text'",
+    "audio_base64": "--ref-audio",
+    "reference_text": "--ref-audio-transcript",
+}
+_FILE_DRIVEN_FIELDS = frozenset(_FILE_DRIVEN_PROVIDERS)
+
+# CLI flags owned by this script (plus argparse's built-in ``help``, which a
+# parameter named "help" would otherwise blow up with "conflicting option
+# string").  A server parameter whose kebab-case name collides with one of
+# these is ignored with a warning instead of silently shadowing a flag.
+_RESERVED_FLAGS = frozenset(
+    (
+        "server",
+        "help",
+        "ref-audio",
+        "ref-audio-transcript",
+        "persona-dir",
+        "output-file",
+        "timeout",
+        "list-server-params",
+    )
+)
+
+_PERSONA_AUDIO_NAME = "ref.wav"
+_PERSONA_TRANSCRIPT_NAME = "ref.txt"
+
+_TRUE_WORDS = frozenset(("true", "yes", "1", "on"))
+_FALSE_WORDS = frozenset(("false", "no", "0", "off"))
+
+
+class SpeakError(Exception):
+    """A user- or server-facing failure that must exit with status 1."""
+
+
+def kebab(name: str) -> str:
+    """Map a server parameter name to its CLI flag (underscores to dashes)."""
+    return name.replace("_", "-")
+
+
+def str_to_bool(value: str) -> bool:
+    """argparse type for boolean parameters.
+
+    argparse's built-in bool coercion treats *any* non-empty string as True,
+    so boolean values are matched against explicit word lists instead.
+    """
+    word = value.strip().lower()
+    if word in _TRUE_WORDS:
+        return True
+    if word in _FALSE_WORDS:
+        return False
+    raise argparse.ArgumentTypeError(
+        f"invalid boolean value: {value!r} (expected one of true/false, yes/no, on/off, 1/0)"
+    )
+
+
+def positive_timeout(value: str) -> int:
+    """argparse type for --timeout: whole seconds, minimum 1.
+
+    urlopen treats 0 as non-blocking and negative values as 'block
+    indefinitely', so a degenerate timeout is rejected at parse time (exit 2)
+    instead of being discovered mid-request.
+    """
+    try:
+        seconds = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}") from exc
+    if seconds < 1:
+        raise argparse.ArgumentTypeError(f"timeout must be at least 1 second (got {seconds})")
+    return seconds
+
+
+def join_url(base: str, path: str) -> str:
+    """Join a server base URL and a path, normalizing duplicate slashes."""
+    return base.rstrip("/") + "/" + path.lstrip("/")
+
+
+def load_audio_base64(path: str) -> str:
+    """Read an audio file and return its base64 encoding (the wire format)."""
+    try:
+        with open(path, "rb") as f:
+            return base64.b64encode(f.read()).decode("ascii")
+    except OSError as exc:
+        raise SpeakError(f"Reference audio file could not be read: {path} ({exc})") from exc
+
+
+def load_transcript(path: str) -> str:
+    """Read a transcript file, collapsing all whitespace to single spaces.
+
+    Transcript files are about words, not line layout, so newlines and runs of
+    spaces are folded exactly like the old ai-playground script did.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = f.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SpeakError(f"Reference transcript file could not be read as UTF-8 text: {path} ({exc})") from exc
+    return " ".join(raw.split())
+
+
+def resolve_reference_sources(
+    ref_audio: str | None, ref_audio_transcript: str | None, persona_dir: str | None
+) -> tuple[str, str | None]:
+    """Resolve the reference flags to concrete file paths.
+
+    Returns ``(audio_path, transcript_path_or_None)``.  ``persona_dir``
+    supersedes both individual flags (with a warning per the spec).  Raises
+    SpeakError for missing or unreadable inputs.
+    """
+    if persona_dir:
+        if ref_audio:
+            print("Warning: --ref-audio ignored because --persona-dir was given.")
+        if ref_audio_transcript:
+            print("Warning: --ref-audio-transcript ignored because --persona-dir was given.")
+        if not os.path.isdir(persona_dir):
+            raise SpeakError(f"Persona directory does not exist or is not a directory: {persona_dir}")
+        if not os.access(persona_dir, os.R_OK):
+            raise SpeakError(f"Persona directory is not readable: {persona_dir}")
+        audio_path = os.path.join(persona_dir, _PERSONA_AUDIO_NAME)
+        transcript_path = os.path.join(persona_dir, _PERSONA_TRANSCRIPT_NAME)
+        _require_readable_file(audio_path, "Persona directory reference audio (ref.wav)")
+        _require_readable_file(transcript_path, "Persona directory reference transcript (ref.txt)")
+        return audio_path, transcript_path
+
+    if ref_audio:
+        _require_readable_file(ref_audio, "Reference audio")
+    if ref_audio_transcript:
+        _require_readable_file(ref_audio_transcript, "Reference transcript")
+    return ref_audio, ref_audio_transcript
+
+
+def _require_readable_file(path: str, label: str) -> None:
+    if not os.path.isfile(path) or not os.access(path, os.R_OK):
+        raise SpeakError(f"{label} not found or not readable: {path}")
+
+
+def check_schema_version(capabilities: dict) -> None:
+    """Reject capabilities documents we do not understand (spec: exit 1)."""
+    if not isinstance(capabilities, dict):
+        # A misrouted URL or chatty gateway can return perfectly valid JSON
+        # that is *not* an object (e.g. []).  That is an unknown document
+        # shape and must fail with the same clean message as everything else,
+        # not with an AttributeError traceback from .get().
+        raise SpeakError(
+            f"Server returned a non-object capabilities document "
+            f"({type(capabilities).__name__}); aborting."
+        )
+    version = capabilities.get("schema_version")
+    if version != SUPPORTED_SCHEMA_VERSION:
+        raise SpeakError(
+            f"Server returned unknown schema version {version}, "
+            f"expected {SUPPORTED_SCHEMA_VERSION}; aborting."
+        )
+
+
+def validate_response(body: object) -> dict:
+    """Enforce the frozen response core: JSON object with non-empty audio_base64."""
+    if not isinstance(body, dict) or not body.get("audio_base64"):
+        raise SpeakError("Invalid response from server.")
+    return body
+
+
+def _http(url: str, data: bytes | None, timeout: int) -> tuple[int, bytes]:
+    """Perform one HTTP request; return (status, body) without raising on HTTP errors."""
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="POST" if data is not None else "GET",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+    except urllib.error.URLError as exc:
+        raise SpeakError(f"Failed to connect to server: {exc.reason}") from exc
+
+
+def _snippet(body: bytes, limit: int = 500) -> str:
+    text = body.decode("utf-8", errors="replace").strip()
+    return text[:limit] if text else "(empty body)"
+
+
+def fetch_json(url: str, timeout: int) -> dict:
+    """GET a JSON document; any failure is a SpeakError (spec: exit 1)."""
+    status, body = _http(url, None, timeout)
+    if not 200 <= status < 300:
+        raise SpeakError(f"GET {url} returned HTTP {status}: {_snippet(body)}")
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SpeakError(f"GET {url} did not return valid JSON: {exc}") from exc
+
+
+def fetch_capabilities(server: str, timeout: int) -> dict:
+    """Fetch GET {server}/capabilities and reject an unknown schema version."""
+    capabilities = fetch_json(join_url(server, "capabilities"), timeout)
+    check_schema_version(capabilities)
+    return capabilities
+
+
+def post_json(url: str, payload: dict, timeout: int) -> object:
+    """POST a JSON payload; any failure is a SpeakError (spec: exit 1)."""
+    status, body = _http(url, json.dumps(payload).encode("utf-8"), timeout)
+    if not 200 <= status < 300:
+        raise SpeakError(f"POST {url} returned HTTP {status}: {_snippet(body)}")
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        # The spec assigns one exact message to "not valid JSON or missing audio".
+        raise SpeakError("Invalid response from server.") from exc
+
+
+def build_base_parser() -> argparse.ArgumentParser:
+    """Stage-1 parser: only the arguments known in advance (spec: 'Proposed new usage')."""
+    parser = argparse.ArgumentParser(
+        prog="speak.py",
+        description=(
+            "Synthesize speech via any tts-serve engine.  Engine-specific parameters "
+            "are discovered from the server's /capabilities endpoint."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  %(prog)s \"Hello, world\" --server http://10.0.0.5:8000 --ref-audio my_voice.wav\n"
+            "  %(prog)s \"Bonjour le monde\" --server http://10.0.0.5:8000 "
+            "--persona-dir ./alice --language fr\n"
+            "  %(prog)s \"Test\" --server http://10.0.0.5:8000 --ref-audio v.wav --output-file out.wav\n"
+            "  %(prog)s --server http://10.0.0.5:8000 --list-server-params\n"
+        ),
+    )
+    # Optional at the argparse level on purpose: --list-server-params needs
+    # no text, and main() turns a missing text into a usage error (exit 1)
+    # for the synthesis path only, before any network traffic.
+    parser.add_argument(
+        "text",
+        nargs="?",
+        default=None,
+        help="Text string to synthesize (not needed with --list-server-params)",
+    )
+    parser.add_argument(
+        "--server",
+        required=True,
+        metavar="URL",
+        help="Server base URL, e.g. http://10.0.0.5:8000. "
+        "The synthesis endpoint is discovered via /capabilities.",
+    )
+    parser.add_argument(
+        "--ref-audio",
+        default=None,
+        metavar="PATH",
+        help="Path to reference audio file (voice cloning). "
+        "At least one of --ref-audio or --persona-dir is required.",
+    )
+    parser.add_argument(
+        "--ref-audio-transcript",
+        default=None,
+        metavar="PATH",
+        help="Path to a text file with the reference audio transcript. "
+        "Ignored (with a warning) by engines that do not accept reference_text.",
+    )
+    parser.add_argument(
+        "--persona-dir",
+        default=None,
+        metavar="DIR",
+        help="Directory containing ref.wav and ref.txt; "
+        "supersedes --ref-audio and --ref-audio-transcript.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        metavar="PATH",
+        help="Path to save the output WAV.  Implies 'silent': the audio is "
+        "saved, not played via aplay.  An existing file prompts for "
+        "overwrite confirmation.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=positive_timeout,
+        default=120,
+        help="Request timeout in seconds, minimum 1 (default: 120).",
+    )
+    parser.add_argument(
+        "--list-server-params",
+        action="store_true",
+        help="Print the engine's /capabilities summary (metadata and the "
+        "flags this script will expose) and exit.  Needs no text or "
+        "reference audio; nothing is synthesized.",
+    )
+    return parser
+
+
+def _parameter_specs(capabilities: dict) -> list[dict]:
+    """The capabilities' parameter entries, narrowed to well-formed dicts.
+
+    A broken document must not take down the stage-2 parser or the
+    --list-server-params printer, so malformed entries are skipped with a
+    warning rather than raising AttributeError from .get().
+    """
+    params = capabilities.get("parameters")
+    if params is None:
+        return []
+    if not isinstance(params, list):
+        print("Warning: 'parameters' in the capabilities document is not a list; ignoring it.")
+        return []
+    specs: list[dict] = []
+    for spec in params:
+        if isinstance(spec, dict):
+            specs.append(spec)
+        else:
+            print(f"Warning: Skipping malformed capabilities parameter entry: {spec!r}")
+    return specs
+
+
+def _coerce_enum(enum: list[object], spec_type: str) -> list[object]:
+    """Coerce the document's enum values into the parameter's own type.
+
+    The capabilities document always carries enum values as strings, while
+    argparse checks ``choices`` *after* applying the flag's type.  Without
+    this, an integer enum like ["1", "2"] could never match the int value
+    the user actually typed.  A value that does not coerce means the
+    document contradicts itself, which is a loud error (R1: never
+    silently misdescribe).
+    """
+
+    def convert(value: object) -> object:
+        if spec_type == "integer":
+            return int(str(value))
+        if spec_type == "number":
+            return float(str(value))
+        if spec_type == "boolean":
+            return str_to_bool(str(value))
+        return value
+
+    coerced: list[object] = []
+    for value in enum:
+        try:
+            coerced.append(convert(value))
+        except (ValueError, argparse.ArgumentTypeError) as exc:
+            raise SpeakError(
+                f"Server advertises enum value {value!r} for a {spec_type} parameter; "
+                f"the capabilities document is inconsistent."
+            ) from exc
+    return coerced
+
+
+def add_dynamic_arguments(parser: argparse.ArgumentParser, capabilities: dict) -> list[str]:
+    """Register one CLI flag per server parameter (stage 2 of the two-stage parse).
+
+    Skips the file-driven fields, warns-and-skips reserved-name collisions,
+    and maps the capabilities types onto argparse (enum to type-coerced
+    choices, boolean to str_to_bool; min/max are deliberately left to the
+    server as source of truth).  Returns the snake_case names added, so the
+    payload builder knows which namespace attributes correspond to server
+    parameters.
+    """
+    added: list[str] = []
+    for spec in _parameter_specs(capabilities):
+        name = spec.get("name", "")
+        if not name or name in _FILE_DRIVEN_FIELDS:
+            continue
+        flag = kebab(name)
+        if flag in _RESERVED_FLAGS:
+            print(f"Warning: Server returned a reserved parameter name {name}; ignoring it.")
+            continue
+        kwargs: dict = {
+            # SUPPRESS => an unspecified optional arg has no namespace attribute
+            # at all, which is how build_payload() knows to omit it.
+            "default": argparse.SUPPRESS,
+            "help": spec.get("description") or None,
+        }
+        if spec.get("required"):
+            kwargs["required"] = True
+        spec_type = spec.get("type", "string")
+        if spec_type == "integer":
+            kwargs["type"] = int
+        elif spec_type == "number":
+            kwargs["type"] = float
+        elif spec_type == "boolean":
+            kwargs["type"] = str_to_bool
+        enum = spec.get("enum")
+        if enum:
+            kwargs["choices"] = _coerce_enum(list(enum), spec_type)
+        parser.add_argument(f"--{flag}", **kwargs)
+        added.append(name)
+    return added
+
+
+def build_payload(
+    args: argparse.Namespace,
+    dynamic_names: list[str],
+    audio_base64: str,
+    reference_text: str | None,
+) -> dict:
+    """Assemble the POST body from user-supplied arguments only.
+
+    Unspecified optional parameters are omitted entirely rather than filled
+    with the server's defaults: a null default (e.g. seed) carries meaning
+    ("pick randomly"), and echoing defaults would only bloat the request.
+    """
+    payload: dict = {"text": args.text, "audio_base64": audio_base64}
+    if reference_text is not None:
+        payload["reference_text"] = reference_text
+    for name in dynamic_names:
+        value = getattr(args, name, None)
+        if value is not None:
+            payload[name] = value
+    return payload
+
+
+def run_aplay(audio_bytes: bytes) -> bool:
+    """Play a WAV buffer via aplay; return True on a clean exit.
+
+    Raises SpeakError when aplay is not installed at all (spec: exit 1).  A
+    non-zero aplay exit is *not* fatal (spec: warn and continue).
+    """
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp.write(audio_bytes)
+            tmp_path = tmp.name
+        result = subprocess.run(["aplay", "-q", tmp_path], check=False)
+        return result.returncode == 0
+    except FileNotFoundError as exc:
+        raise SpeakError(
+            "'aplay' not found. Please install the ALSA utilities (e.g. 'sudo apt install alsa-utils')."
+        ) from exc
+    finally:
+        # Guarded: if temp-file creation itself fails, an unguarded
+        # os.unlink(tmp.name) would raise NameError and mask the real error.
+        if tmp_path is not None:
+            os.unlink(tmp_path)
+
+
+def _confirm_overwrite(path: str) -> bool:
+    try:
+        answer = input(f"File '{path}' already exists. Overwrite? [y/N] ").strip().lower()
+    except EOFError:
+        # No interactive stdin (piped invocation): treat as a decline.
+        return False
+    return answer == "y"
+
+
+def save_or_play(audio_bytes: bytes, output_file: str | None) -> None:
+    """Either save the audio to output_file or play it via aplay — never both.
+
+    Per the spec ('Output'), --output-file is an implied "silent" option: it
+    lets the user keep the returned audio on boxes with no aplay at all.
+    Declining the overwrite prompt silently discards the audio (not an error).
+    """
+    if output_file:
+        if os.path.exists(output_file) and not _confirm_overwrite(output_file):
+            return
+        try:
+            with open(output_file, "wb") as f:
+                f.write(audio_bytes)
+        except OSError as exc:
+            raise SpeakError(f"Could not write output file {output_file}: {exc}") from exc
+        print(f"Saved audio to {output_file}")
+        return
+    if not run_aplay(audio_bytes):
+        print("Warning: aplay returned a non-zero exit code; audio may not have played.")
+
+
+def _format_stats(response: dict) -> str:
+    rtf = response.get("rtf")
+    return (
+        f"seed={response.get('seed')} "
+        f"time_used={response.get('time_used')}s "
+        f"rtf={'null' if rtf is None else rtf}"
+    )
+
+
+def _format_number(value: object) -> str:
+    """Render a JSON number without a spurious .0 (64.0 -> '64')."""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _format_default(value: object) -> str:
+    return "null" if value is None else _format_number(value)
+
+
+def format_server_params(capabilities: dict) -> str:
+    """Render the --list-server-params summary.
+
+    Engine metadata first, then the exact flags this script will expose for
+    the engine's parameters (file-driven fields are shown with the CLI flag
+    that supplies them, reserved collisions are marked as ignored).
+    """
+    lines: list[str] = [
+        f"Engine:      {capabilities.get('engine', '?')}",
+        f"Model:       {capabilities.get('model', '?')}",
+        f"Device:      {capabilities.get('device', '?')}",
+        f"Sample rate: {capabilities.get('sample_rate', '?')} Hz",
+        f"Watermarked: {'yes' if capabilities.get('watermarked') else 'no'}",
+        f"Endpoint:    {capabilities.get('endpoint') or '/synthesize'}",
+    ]
+    languages = capabilities.get("languages")
+    lines.append(f"Languages:   {', '.join(languages) if languages else '(none advertised)'}")
+
+    reference = capabilities.get("reference_audio")
+    if isinstance(reference, dict):
+        bits = ["required" if reference.get("required") else "optional"]
+        if reference.get("formats"):
+            bits.append("formats: " + ", ".join(reference["formats"]))
+        max_duration = reference.get("max_duration_s")
+        if max_duration is not None:
+            bits.append(f"max {_format_number(max_duration)}s")
+        lines.append("Reference:   " + ", ".join(bits))
+        if reference.get("note"):
+            lines.append(textwrap.indent(textwrap.fill(str(reference["note"]), width=68), "              "))
+    else:
+        lines.append("Reference:   not supported by this engine")
+
+    lines.append("")
+    lines.append("Parameters (this script's flags for them):")
+    for spec in _parameter_specs(capabilities):
+        name = spec.get("name", "")
+        if not name:
+            continue
+        spec_type = spec.get("type", "string")
+        required = bool(spec.get("required"))
+        if name in _FILE_DRIVEN_PROVIDERS:
+            flag = _FILE_DRIVEN_PROVIDERS[name]
+        else:
+            flag = f"--{kebab(name)}"
+        default = "" if required else f"  (default: {_format_default(spec.get('default'))})"
+        lines.append(f"  {flag:<28} {spec_type:<8} {'required' if required else 'optional'}{default}")
+        if flag.startswith("--") and kebab(name) in _RESERVED_FLAGS:
+            lines.append("      [ignored by this script: reserved flag name]")
+        description = str(spec.get("description") or "").strip()
+        if description:
+            lines.append(textwrap.indent(textwrap.fill(description, width=68), "    "))
+        enum = spec.get("enum")
+        if enum:
+            lines.append(f"    choices: {', '.join(str(v) for v in enum)}")
+        if spec.get("min") is not None or spec.get("max") is not None:
+            lo = spec.get("min")
+            hi = spec.get("max")
+            lo_text = "" if lo is None else _format_number(lo)
+            hi_text = "" if hi is None else _format_number(hi)
+            lines.append(f"    range: {lo_text}..{hi_text}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _fail(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the tool; return the process exit code (0 ok, 1 error; argparse exits 2)."""
+    # Stage 1: parse only the arguments known in advance.  Unknown tokens pass
+    # through unvalidated; argparse itself still exits 2 for missing --server
+    # or -h.  The text positional and the reference flags are checked below,
+    # after --list-server-params has had a chance to short-circuit, because
+    # the listing needs neither.
+    parser = build_base_parser()
+    args, _unknown = parser.parse_known_args(argv)
+
+    # Discovery only: no text, no reference audio, no synthesis.
+    if args.list_server_params:
+        try:
+            capabilities = fetch_capabilities(args.server, args.timeout)
+        except SpeakError as exc:
+            return _fail(str(exc))
+        print(format_server_params(capabilities))
+        return 0
+
+    # Fail fast, before any network traffic: every tts-serve engine requires
+    # text and a reference clip, so missing sources are usage errors, not
+    # server errors.
+    if args.text is None:
+        return _fail("You must supply the text to synthesize!")
+    if not args.ref_audio and not args.persona_dir:
+        return _fail("You must supply reference audio or a persona directory!")
+
+    try:
+        capabilities = fetch_capabilities(args.server, args.timeout)
+    except SpeakError as exc:
+        return _fail(str(exc))
+
+    try:
+        dynamic_names = add_dynamic_arguments(parser, capabilities)
+    except SpeakError as exc:
+        return _fail(str(exc))
+    except argparse.ArgumentError as exc:
+        return _fail(f"Cannot register server parameter: {exc}")
+    # Stage 2, same parser object: re-parses the entire command line strictly,
+    # so engine-specific typos and type errors now exit 2.
+    args = parser.parse_args(argv)
+
+    try:
+        audio_path, transcript_path = resolve_reference_sources(
+            args.ref_audio, args.ref_audio_transcript, args.persona_dir
+        )
+        accepts_reference_text = any(
+            p.get("name") == "reference_text" for p in _parameter_specs(capabilities)
+        )
+        reference_text = None
+        if transcript_path is not None:
+            if accepts_reference_text:
+                reference_text = load_transcript(transcript_path)
+            else:
+                print("Warning: Reference text ignored as this server does not accept it.")
+        audio_base64 = load_audio_base64(audio_path)
+    except SpeakError as exc:
+        return _fail(str(exc))
+
+    payload = build_payload(args, dynamic_names, audio_base64, reference_text)
+
+    try:
+        endpoint = capabilities.get("endpoint") or "/synthesize"
+        response = post_json(join_url(args.server, endpoint), payload, args.timeout)
+        validate_response(response)
+    except SpeakError as exc:
+        return _fail(str(exc))
+
+    # Log the response stats before playing/saving: if audio output fails, the
+    # user still sees what the engine produced (spec: 'Output', new behaviour).
+    print(_format_stats(response))
+
+    try:
+        audio_bytes = base64.b64decode(response["audio_base64"])
+    except (binascii.Error, KeyError, TypeError) as exc:
+        return _fail("Invalid response from server.")
+    try:
+        save_or_play(audio_bytes, args.output_file)
+    except SpeakError as exc:
+        return _fail(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Make tools/speak.py importable as ``speak`` from this test suite.
+
+Inserted at position 0 deliberately (the reverse of impl/tests' stub
+strategy): these tests must exercise *this repo's* speak.py, so it must win
+over any coincidentally-named installed package.
+"""
+
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = str(Path(__file__).resolve().parents[1])
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)

--- a/tools/tests/test_speak.py
+++ b/tools/tests/test_speak.py
@@ -1,0 +1,948 @@
+"""GPU-free unit tests for tools/speak.py.
+
+Covers the areas docs/03-speak-script.md calls out: capabilities-parser
+mapping, payload assembly, persona-dir resolution, base64 handling, and
+reference-text whitespace collapsing, plus end-to-end ``main()`` flows with
+the network and aplay stubbed out.  The capabilities-driven tests run
+against the real committed server snapshots in impl/tests/snapshots/, so a
+server schema change that breaks the mapping shows up here.
+"""
+
+import argparse
+import base64
+import json
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+import speak
+
+SNAPSHOTS = Path(__file__).resolve().parents[2] / "impl" / "tests" / "snapshots"
+
+
+def _caps(filename: str) -> dict:
+    return json.loads((SNAPSHOTS / filename).read_text(encoding="utf-8"))
+
+
+def _dots_parser():
+    parser = speak.build_base_parser()
+    names = speak.add_dynamic_arguments(parser, _caps("dots_capabilities.json"))
+    return parser, names
+
+
+def _stage_two_args(parser, extra: list[str] | None = None):
+    """A command line that satisfies all stage-1 required arguments."""
+    base = ["Hello", "--server", "http://10.0.0.5:8000", "--ref-audio", "a.wav"]
+    return parser.parse_args(base + (extra or []))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_kebab_withUnderscores_replacesWithDashes():
+    # GIVEN a server parameter name with underscores
+    # WHEN mapped to a CLI flag
+    # THEN it follows the kebab-case convention
+    assert speak.kebab("num_steps") == "num-steps"
+
+
+def test_kebab_withoutUnderscores_isUnchanged():
+    assert speak.kebab("guidance") == "guidance"
+
+
+@pytest.mark.parametrize("word", ["true", "yes", "1", "on", "True", "ON"])
+def test_str_to_bool_withTruthyWord_returnsTrue(word):
+    assert speak.str_to_bool(word) is True
+
+
+@pytest.mark.parametrize("word", ["false", "no", "0", "off", "False", "OFF"])
+def test_str_to_bool_withFalsyWord_returnsFalse(word):
+    assert speak.str_to_bool(word) is False
+
+
+def test_str_to_bool_withNonBooleanWord_raisesArgumentTypeError():
+    # GIVEN a string that is not in the true/false word lists
+    # WHEN parsed as a boolean
+    # THEN argparse gets an ArgumentTypeError (which becomes exit 2)
+    with pytest.raises(argparse.ArgumentTypeError):
+        speak.str_to_bool("test")
+
+
+def test_join_url_withTrailingAndLeadingSlashes_normalizesToSingleSlash():
+    assert (
+        speak.join_url("http://10.0.0.5:8000/", "/synthesize")
+        == "http://10.0.0.5:8000/synthesize"
+    )
+
+
+def test_join_url_withNoSlashes_addsSeparator():
+    assert speak.join_url("http://10.0.0.5:8000", "synthesize") == "http://10.0.0.5:8000/synthesize"
+
+
+def test_load_audio_base64_roundTripsOriginalBytes(tmp_path):
+    # GIVEN a binary audio file
+    # WHEN base64-encoded by the script
+    # THEN decoding yields the original bytes
+    data = bytes(range(256)) * 10
+    path = tmp_path / "ref.wav"
+    path.write_bytes(data)
+    assert base64.b64decode(speak.load_audio_base64(str(path))) == data
+
+
+def test_load_transcript_withMessyWhitespace_collapsesToSingleSpaces(tmp_path):
+    # GIVEN a transcript file with leading/trailing whitespace and newlines
+    # WHEN loaded
+    # THEN all whitespace runs collapse to single spaces
+    path = tmp_path / "ref.txt"
+    path.write_text("  Hello,   world.\n\nLine two.\n", encoding="utf-8")
+    assert speak.load_transcript(str(path)) == "Hello, world. Line two."
+
+
+def test_load_transcript_withNonUtf8File_raisesSpeakError(tmp_path):
+    path = tmp_path / "ref.txt"
+    path.write_bytes(b"\xff\xfe\x00binary")
+    with pytest.raises(speak.SpeakError, match="could not be read as UTF-8"):
+        speak.load_transcript(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 parser: --timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["0", "-5", "abc"])
+def test_build_base_parser_withBadTimeout_exits2(value):
+    # GIVEN a zero, negative, or non-numeric timeout
+    # WHEN parsed
+    # THEN argparse rejects it (exit 2) instead of letting urlopen do
+    #      something degenerate with it (0 = non-blocking, < 0 = block
+    #      indefinitely)
+    parser = speak.build_base_parser()
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(
+            ["Hi", "--server", "http://x", "--ref-audio", "a.wav", "--timeout", value]
+        )
+    assert excinfo.value.code == 2
+
+
+def test_build_base_parser_withValidTimeout_parsesIt():
+    parser = speak.build_base_parser()
+    args = parser.parse_args(
+        ["Hi", "--server", "http://x", "--ref-audio", "a.wav", "--timeout", "30"]
+    )
+    assert args.timeout == 30
+
+
+# ---------------------------------------------------------------------------
+# Capabilities handling
+# ---------------------------------------------------------------------------
+
+
+def test_check_schema_version_withSupportedVersion_doesNotRaise():
+    speak.check_schema_version({"schema_version": speak.SUPPORTED_SCHEMA_VERSION})
+
+
+def test_check_schema_version_withFutureVersion_raisesWithExactMessage():
+    # GIVEN a capabilities document with a newer schema version
+    # WHEN checked
+    # THEN the spec's exact error message is produced
+    with pytest.raises(speak.SpeakError, match=r"unknown schema version 3, expected 2; aborting\."):
+        speak.check_schema_version({"schema_version": 3})
+
+
+def test_check_schema_version_withListDocument_raisesWithCleanMessage():
+    # GIVEN a server that answered with valid JSON that is not an object
+    #      (e.g. a misrouted URL hitting a chatty gateway)
+    # WHEN checked
+    # THEN a clean SpeakError is raised, not an AttributeError from .get()
+    with pytest.raises(speak.SpeakError, match=r"non-object capabilities document \(list\)"):
+        speak.check_schema_version(["not", "an", "object"])
+
+
+def test_parameter_specs_withMalformedEntries_skipsThemWithWarnings(capsys):
+    # GIVEN a parameters list containing non-dict entries
+    # WHEN narrowed
+    # THEN only well-formed entries survive, each skip is warned about
+    specs = speak._parameter_specs({"parameters": [{"name": "ok", "type": "string"}, "junk", 42]})
+    assert [s.get("name") for s in specs] == ["ok"]
+    out = capsys.readouterr().out
+    assert "Skipping malformed capabilities parameter entry: 'junk'" in out
+    assert "Skipping malformed capabilities parameter entry: 42" in out
+
+
+def test_parameter_specs_withNonListParameters_warnsAndReturnsEmpty(capsys):
+    # GIVEN a capabilities document whose 'parameters' is a dict, not a list
+    # WHEN narrowed
+    # THEN nothing is registered and the user is warned
+    assert speak._parameter_specs({"parameters": {"name": "oops"}}) == []
+    assert "is not a list" in capsys.readouterr().out
+
+
+def test_validate_response_withMissingAudioBase64_raises():
+    with pytest.raises(speak.SpeakError, match=r"Invalid response from server\."):
+        speak.validate_response({"seed": 1})
+
+
+def test_validate_response_withEmptyAudioBase64_raises():
+    with pytest.raises(speak.SpeakError, match=r"Invalid response from server\."):
+        speak.validate_response({"audio_base64": ""})
+
+
+def test_validate_response_withNonObjectBody_raises():
+    with pytest.raises(speak.SpeakError, match=r"Invalid response from server\."):
+        speak.validate_response(["not", "an", "object"])
+
+
+def test_validate_response_withValidBody_returnsBody():
+    body = {"audio_base64": "AAAA", "seed": 1, "time_used": 1.0, "rtf": None}
+    assert speak.validate_response(body) is body
+
+
+# ---------------------------------------------------------------------------
+# Capabilities -> argparse mapping (stage 2)
+# ---------------------------------------------------------------------------
+
+
+def test_add_dynamic_arguments_withDotsCapabilities_addsExactlyTheNonFileDrivenParams():
+    # GIVEN the real dots.tts capabilities document
+    # WHEN dynamic arguments are registered
+    # THEN text/audio_base64/reference_text are skipped and the rest, in
+    #      declaration order, become CLI flags
+    _, names = _dots_parser()
+    assert names == ["language", "seed", "num_steps", "guidance_scale", "speaker_scale", "ode_method"]
+
+
+def test_add_dynamic_arguments_withReservedName_warnsAndSkips(capsys):
+    # GIVEN a server advertising a parameter named like a reserved flag
+    # WHEN dynamic arguments are registered
+    # THEN it is skipped with the spec's exact warning
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "output_file", "type": "string", "required": False}]}
+    names = speak.add_dynamic_arguments(parser, caps)
+    assert names == []
+    assert "Warning: Server returned a reserved parameter name output_file; ignoring it." in capsys.readouterr().out
+
+
+def test_add_dynamic_arguments_withHelpParam_warnsAndSkipsInsteadOfCrashing(capsys):
+    # GIVEN a server advertising a parameter named 'help' — a legal Pydantic
+    #      field name that would collide with argparse's built-in
+    # WHEN dynamic arguments are registered
+    # THEN it is skipped with the reserved-name warning, not an
+    #      unhandled ArgumentError ("conflicting option string")
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "help", "type": "string", "required": False, "enum": None}]}
+    names = speak.add_dynamic_arguments(parser, caps)
+    assert names == []
+    assert "Warning: Server returned a reserved parameter name help; ignoring it." in capsys.readouterr().out
+
+
+def test_add_dynamic_arguments_withEnum_acceptsValidChoice():
+    # GIVEN the dots.tts ode_method enum (euler/midpoint/rk4)
+    # WHEN a valid choice is supplied
+    # THEN it is accepted
+    parser, _ = _dots_parser()
+    args = _stage_two_args(parser, ["--ode-method", "rk4"])
+    assert args.ode_method == "rk4"
+
+
+def test_add_dynamic_arguments_withEnum_rejectsInvalidChoiceWithExit2():
+    parser, _ = _dots_parser()
+    with pytest.raises(SystemExit) as excinfo:
+        _stage_two_args(parser, ["--ode-method", "bogus"])
+    assert excinfo.value.code == 2
+
+
+def test_add_dynamic_arguments_withRequiredParam_omittedExits2():
+    # GIVEN a required engine parameter
+    # WHEN the user omits it
+    # THEN argparse enforces it with exit 2
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "mandatory", "type": "integer", "required": True}]}
+    speak.add_dynamic_arguments(parser, caps)
+    with pytest.raises(SystemExit) as excinfo:
+        _stage_two_args(parser)
+    assert excinfo.value.code == 2
+
+
+def test_add_dynamic_arguments_withUnrecognizedArg_exits2():
+    parser, _ = _dots_parser()
+    with pytest.raises(SystemExit) as excinfo:
+        _stage_two_args(parser, ["--does-not-exist", "1"])
+    assert excinfo.value.code == 2
+
+
+def test_add_dynamic_arguments_withInvalidIntValue_exits2():
+    # GIVEN the integer parameter num_steps
+    # WHEN given a non-numeric string
+    # THEN argparse's type check fails with exit 2
+    parser, _ = _dots_parser()
+    with pytest.raises(SystemExit) as excinfo:
+        _stage_two_args(parser, ["--num-steps", "test"])
+    assert excinfo.value.code == 2
+
+
+def test_add_dynamic_arguments_withBooleanParam_parsesWordValues():
+    # GIVEN a boolean engine parameter
+    # WHEN given a word-list value
+    # THEN it parses to a real bool
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "loud", "type": "boolean", "required": False}]}
+    speak.add_dynamic_arguments(parser, caps)
+    args = _stage_two_args(parser, ["--loud", "yes"])
+    assert args.loud is True
+
+
+def test_add_dynamic_arguments_withBooleanParam_rejectsArbitraryString():
+    # GIVEN a boolean engine parameter
+    # WHEN given a string outside the word lists
+    # THEN it is rejected with exit 2 (argparse's bool would have said True!)
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "loud", "type": "boolean", "required": False}]}
+    speak.add_dynamic_arguments(parser, caps)
+    with pytest.raises(SystemExit) as excinfo:
+        _stage_two_args(parser, ["--loud", "maybe"])
+    assert excinfo.value.code == 2
+
+
+def test_add_dynamic_arguments_withNumberParam_acceptsFloatValue():
+    parser, _ = _dots_parser()
+    args = _stage_two_args(parser, ["--guidance-scale", "2.5"])
+    assert args.guidance_scale == 2.5
+
+
+def test_add_dynamic_arguments_withIntegerEnum_coercesChoicesAndAcceptsValue():
+    # GIVEN an integer parameter with a stringified enum (capabilities always
+    #      carry enum values as strings)
+    # WHEN a value within the enum is supplied
+    # THEN argparse's type conversion yields a value that actually matches
+    #      the coerced choices (raw string choices could never match an int)
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "mode", "type": "integer", "required": False, "enum": ["1", "2"]}]}
+    speak.add_dynamic_arguments(parser, caps)
+    args = _stage_two_args(parser, ["--mode", "1"])
+    assert args.mode == 1
+
+
+def test_add_dynamic_arguments_withIntegerEnum_rejectsValueOutsideEnum():
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "mode", "type": "integer", "required": False, "enum": ["1", "2"]}]}
+    speak.add_dynamic_arguments(parser, caps)
+    with pytest.raises(SystemExit) as excinfo:
+        _stage_two_args(parser, ["--mode", "3"])
+    assert excinfo.value.code == 2
+
+
+def test_add_dynamic_arguments_withInconsistentEnum_raisesSpeakError():
+    # GIVEN an integer parameter advertising a non-numeric enum value:
+    #      the document contradicts itself
+    # WHEN the enum is coerced
+    # THEN a loud SpeakError is raised rather than a silent misparse
+    parser = speak.build_base_parser()
+    caps = {"parameters": [{"name": "mode", "type": "integer", "required": False, "enum": ["1", "banana"]}]}
+    with pytest.raises(speak.SpeakError, match=r"enum value 'banana'"):
+        speak.add_dynamic_arguments(parser, caps)
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+
+def test_build_payload_withOnlyCoreArgs_containsExactlyCoreFields():
+    args = argparse.Namespace(text="hi")
+    payload = speak.build_payload(args, [], "AQID", None)
+    assert payload == {"text": "hi", "audio_base64": "AQID"}
+
+
+def test_build_payload_withSuppliedDynamicArg_includesIt():
+    args = argparse.Namespace(text="hi", seed=42)
+    payload = speak.build_payload(args, ["seed"], "AQID", None)
+    assert payload["seed"] == 42
+
+
+def test_build_payload_withUnsuppliedDynamicArg_omitsIt():
+    # GIVEN an optional dynamic arg the user never supplied (no namespace
+    # attribute, thanks to default=SUPPRESS)
+    # WHEN the payload is assembled
+    # THEN it is omitted rather than filled with its default
+    args = argparse.Namespace(text="hi")
+    payload = speak.build_payload(args, ["seed"], "AQID", None)
+    assert "seed" not in payload
+
+
+def test_build_payload_withTranscript_includesReferenceText():
+    args = argparse.Namespace(text="hi")
+    payload = speak.build_payload(args, [], "AQID", "hello there")
+    assert payload["reference_text"] == "hello there"
+
+
+def test_build_payload_withoutTranscript_omitsReferenceText():
+    args = argparse.Namespace(text="hi")
+    payload = speak.build_payload(args, [], "AQID", None)
+    assert "reference_text" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Reference source resolution (flags + persona dir)
+# ---------------------------------------------------------------------------
+
+
+def _make_persona(directory: Path, audio: bytes = b"WAV", transcript: str = "ref words") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "ref.wav").write_bytes(audio)
+    (directory / "ref.txt").write_text(transcript, encoding="utf-8")
+    return directory
+
+
+def test_resolve_reference_sources_withPersonaDirAndBothFlags_personaWinsAndWarns(tmp_path, capsys):
+    # GIVEN both the individual flags and a persona dir
+    # WHEN resolved
+    # THEN the persona dir wins and both flags are ignored with warnings
+    persona = _make_persona(tmp_path / "alice")
+    audio, transcript = speak.resolve_reference_sources("a.wav", "t.txt", str(persona))
+    assert audio == str(persona / "ref.wav")
+    assert transcript == str(persona / "ref.txt")
+    out = capsys.readouterr().out
+    assert "Warning: --ref-audio ignored because --persona-dir was given." in out
+    assert "Warning: --ref-audio-transcript ignored because --persona-dir was given." in out
+
+
+def test_resolve_reference_sources_withMissingPersonaDir_raises(tmp_path):
+    with pytest.raises(speak.SpeakError, match=r"Persona directory does not exist"):
+        speak.resolve_reference_sources(None, None, str(tmp_path / "nope"))
+
+
+def test_resolve_reference_sources_withPersonaDirMissingRefWav_raises(tmp_path):
+    (tmp_path / "ref.txt").write_text("x", encoding="utf-8")
+    with pytest.raises(speak.SpeakError, match=r"ref\.wav"):
+        speak.resolve_reference_sources(None, None, str(tmp_path))
+
+
+def test_resolve_reference_sources_withPersonaDirMissingRefTxt_raises(tmp_path):
+    (tmp_path / "ref.wav").write_bytes(b"x")
+    with pytest.raises(speak.SpeakError, match=r"ref\.txt"):
+        speak.resolve_reference_sources(None, None, str(tmp_path))
+
+
+def test_resolve_reference_sources_withRefAudioOnly_resolvesAudioAndNoTranscript(tmp_path):
+    (tmp_path / "a.wav").write_bytes(b"WAV")
+    audio, transcript = speak.resolve_reference_sources(str(tmp_path / "a.wav"), None, None)
+    assert audio == str(tmp_path / "a.wav")
+    assert transcript is None
+
+
+def test_resolve_reference_sources_withMissingRefAudioFile_raises(tmp_path):
+    with pytest.raises(speak.SpeakError, match=r"not found or not readable"):
+        speak.resolve_reference_sources(str(tmp_path / "missing.wav"), None, None)
+
+
+def test_resolve_reference_sources_withMissingRefTranscriptFile_raises(tmp_path):
+    with pytest.raises(speak.SpeakError, match=r"not found or not readable"):
+        speak.resolve_reference_sources(None, str(tmp_path / "missing.txt"), None)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end main() with network + aplay stubbed
+# ---------------------------------------------------------------------------
+
+
+def _stub_network(monkeypatch, caps, response, seen=None, urls=None):
+    if seen is None:
+        seen = {}
+    if urls is None:
+        urls = []
+    monkeypatch.setattr(
+        speak, "fetch_json", lambda url, timeout: (urls.append(url), caps)[1]
+    )
+    monkeypatch.setattr(
+        speak, "post_json",
+        lambda url, payload, timeout: (urls.append(url), seen.update(payload), response)[2],
+    )
+
+
+def _ok_response() -> dict:
+    return {
+        "audio_base64": base64.b64encode(b"WAVDATA").decode("ascii"),
+        "sample_rate": 24000,
+        "seed": 7,
+        "time_used": 1.5,
+        "rtf": 0.3,
+    }
+
+
+def _aplay_spy(monkeypatch) -> list[bytes]:
+    """Stub run_aplay, recording every call — used to prove the silent path."""
+    calls: list[bytes] = []
+
+    def spy(audio: bytes) -> bool:
+        calls.append(audio)
+        return True
+
+    monkeypatch.setattr(speak, "run_aplay", spy)
+    return calls
+
+
+def test_main_happyPath_savesFileLogsStatsAndReturnsZero(tmp_path, monkeypatch, capsys):
+    # GIVEN a chatterbox-style server (no reference_text param) and a real ref file
+    caps = _caps("chatterbox_capabilities.json")
+    seen, urls = {}, []
+    _stub_network(monkeypatch, caps, _ok_response(), seen, urls)
+    aplay_calls = _aplay_spy(monkeypatch)
+    (tmp_path / "ref.wav").write_bytes(b"REF")
+    out_file = tmp_path / "out.wav"
+
+    # WHEN the user synthesizes with a trailing-slash server URL and --seed
+    code = speak.main(
+        [
+            "Hello",
+            "--server", "http://10.0.0.5:8000/",
+            "--ref-audio", str(tmp_path / "ref.wav"),
+            "--seed", "7",
+            "--output-file", str(out_file),
+        ]
+    )
+
+    # THEN exit 0, the payload carries the core fields, the URLs use the
+    #      advertised endpoint with normalized slashes, and stats are logged
+    assert code == 0
+    assert out_file.read_bytes() == b"WAVDATA"
+    assert aplay_calls == []  # --output-file is implied "silent": never plays
+    assert seen == {"text": "Hello", "audio_base64": base64.b64encode(b"REF").decode(), "seed": 7}
+    assert urls == [
+        "http://10.0.0.5:8000/capabilities",
+        "http://10.0.0.5:8000/synthesize",
+    ]
+    out = capsys.readouterr().out
+    assert "seed=7" in out
+    assert "time_used=1.5s" in out
+    assert "rtf=0.3" in out
+    assert "Saved audio to" in out
+
+
+def test_main_withPersonaDir_usesRefWavAndRefTxt(tmp_path, monkeypatch):
+    caps = _caps("dots_capabilities.json")  # advertises reference_text
+    seen = {}
+    _stub_network(monkeypatch, caps, _ok_response(), seen)
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    persona = _make_persona(tmp_path / "alice", audio=b"PERSONA", transcript="alice words")
+
+    code = speak.main(["Hello", "--server", "http://x", "--persona-dir", str(persona)])
+
+    assert code == 0
+    assert base64.b64decode(seen["audio_base64"]) == b"PERSONA"
+    assert seen["reference_text"] == "alice words"
+
+
+def test_main_withTranscriptOnServerWithoutReferenceText_warnsAndOmitsField(tmp_path, monkeypatch, capsys):
+    # GIVEN a server that does not advertise reference_text (chatterbox)
+    caps = _caps("chatterbox_capabilities.json")
+    seen = {}
+    _stub_network(monkeypatch, caps, _ok_response(), seen)
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+    (tmp_path / "t.txt").write_text("  words  here\n", encoding="utf-8")
+
+    # WHEN the user still supplies a transcript
+    code = speak.main(
+        ["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav"),
+         "--ref-audio-transcript", str(tmp_path / "t.txt")]
+    )
+
+    # THEN it is ignored with the spec's warning, and the field is not sent
+    assert code == 0
+    assert "reference_text" not in seen
+    assert "Warning: Reference text ignored as this server does not accept it." in capsys.readouterr().out
+
+
+def test_main_withTranscriptOnServerWithReferenceText_sendsCollapsedText(tmp_path, monkeypatch):
+    caps = _caps("dots_capabilities.json")  # advertises reference_text
+    seen = {}
+    _stub_network(monkeypatch, caps, _ok_response(), seen)
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+    (tmp_path / "t.txt").write_text("  words  here\n", encoding="utf-8")
+
+    code = speak.main(
+        ["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav"),
+         "--ref-audio-transcript", str(tmp_path / "t.txt")]
+    )
+
+    assert code == 0
+    assert seen["reference_text"] == "words here"
+
+
+def test_main_withNoReferenceAudioAtAll_exits1BeforeAnyNetworkCall(monkeypatch, capsys):
+    # GIVEN no --ref-audio and no --persona-dir
+    called = []
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: called.append(url))
+
+    # WHEN main runs
+    code = speak.main(["Hello", "--server", "http://x"])
+
+    # THEN it fails locally (exit 1, spec's message) without touching the network
+    assert code == 1
+    assert called == []
+    assert "You must supply reference audio or a persona directory!" in capsys.readouterr().err
+
+
+def test_main_withoutText_exits1BeforeAnyNetworkCall(tmp_path, monkeypatch, capsys):
+    # GIVEN no text positional (the reference file is fine)
+    called = []
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: called.append(url))
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    # WHEN main runs without a text argument
+    code = speak.main(["--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    # THEN it fails locally (exit 1) without touching the network
+    assert code == 1
+    assert called == []
+    assert "You must supply the text to synthesize!" in capsys.readouterr().err
+
+
+def test_main_withUnknownSchemaVersion_exits1WithMessage(tmp_path, monkeypatch, capsys):
+    caps = _caps("dots_capabilities.json")
+    caps["schema_version"] = 99
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: caps)
+
+    code = speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    assert code == 1
+    assert "Server returned unknown schema version 99, expected 2; aborting." in capsys.readouterr().err
+
+
+def test_main_withUnreachableServer_exits1(tmp_path, monkeypatch, capsys):
+    def boom(url, timeout):
+        raise speak.SpeakError(f"Failed to connect to server: {url}")
+
+    monkeypatch.setattr(speak, "fetch_json", boom)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    code = speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    assert code == 1
+    assert "Failed to connect to server" in capsys.readouterr().err
+
+
+def test_main_withUnrecognizedEngineArg_exits2(tmp_path, monkeypatch):
+    caps = _caps("dots_capabilities.json")
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: caps)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav"),
+                    "--does-not-exist", "1"])
+    assert excinfo.value.code == 2
+
+
+def test_main_withMissingRequiredEngineArg_exits2(tmp_path, monkeypatch):
+    caps = {
+        "schema_version": 2,  # required: the script rejects unknown versions pre-parse
+        "parameters": [
+            {"name": "text", "type": "string", "required": True},
+            {"name": "audio_base64", "type": "string", "required": True},
+            {"name": "mandatory", "type": "integer", "required": True},
+        ],
+    }
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: caps)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+    assert excinfo.value.code == 2
+
+
+def test_main_withEmptyAudioResponse_exits1WithInvalidResponseMessage(tmp_path, monkeypatch, capsys):
+    caps = _caps("dots_capabilities.json")
+    _stub_network(monkeypatch, caps, {"seed": 1})
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    code = speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    assert code == 1
+    assert "Invalid response from server." in capsys.readouterr().err
+
+
+def test_main_whenAplayMissing_exits1AfterLoggingStats(tmp_path, monkeypatch, capsys):
+    caps = _caps("dots_capabilities.json")
+    _stub_network(monkeypatch, caps, _ok_response())
+
+    def no_aplay(audio):
+        raise speak.SpeakError("'aplay' not found. Please install the ALSA utilities.")
+
+    monkeypatch.setattr(speak, "run_aplay", no_aplay)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    # WHEN aplay is missing, synthesis stats were already logged (spec: log
+    #      before play/save), then exit 1
+    code = speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "seed=7" in captured.out  # stats logged before the playback attempt failed
+    assert "'aplay' not found" in captured.err
+
+
+def test_main_whenAplayFailsWithoutOutputFile_warnsAndExits0(tmp_path, monkeypatch, capsys):
+    # GIVEN the play path (no --output-file) and aplay that exits non-zero
+    caps = _caps("dots_capabilities.json")
+    _stub_network(monkeypatch, caps, _ok_response())
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: False)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    code = speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    # THEN aplay's failure is a warning, not an error: audio discarded, exit 0
+    assert code == 0
+    assert "Warning: aplay returned a non-zero exit code" in capsys.readouterr().out
+
+
+def test_main_withExistingOutputFileAndDeclinedOverwrite_discardsAudioSilently(tmp_path, monkeypatch):
+    # GIVEN an existing output file and a "n" answer at the overwrite prompt
+    caps = _caps("dots_capabilities.json")
+    _stub_network(monkeypatch, caps, _ok_response())
+    aplay_calls = _aplay_spy(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda *a: "n")
+    (tmp_path / "a.wav").write_bytes(b"REF")
+    out_file = tmp_path / "o.wav"
+    out_file.write_bytes(b"OLD")
+
+    code = speak.main(
+        ["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav"),
+         "--output-file", str(out_file)]
+    )
+
+    # THEN declining is not an error, the old file is untouched, and nothing
+    #      is played: the silent path never falls through to aplay
+    assert code == 0
+    assert out_file.read_bytes() == b"OLD"
+    assert aplay_calls == []
+
+
+def test_main_withExistingOutputFileAndAcceptedOverwrite_replacesFileWithoutPlaying(tmp_path, monkeypatch):
+    caps = _caps("dots_capabilities.json")
+    _stub_network(monkeypatch, caps, _ok_response())
+    aplay_calls = _aplay_spy(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda *a: "y")
+    (tmp_path / "a.wav").write_bytes(b"REF")
+    out_file = tmp_path / "o.wav"
+    out_file.write_bytes(b"OLD")
+
+    code = speak.main(
+        ["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav"),
+         "--output-file", str(out_file)]
+    )
+
+    # THEN the file is replaced and the silent path never touches aplay
+    assert code == 0
+    assert out_file.read_bytes() == b"WAVDATA"
+    assert aplay_calls == []
+
+
+def test_main_withPersonaDirAndIndividualFlags_warnsAboutIgnoredFlags(tmp_path, monkeypatch, capsys):
+    caps = _caps("dots_capabilities.json")
+    _stub_network(monkeypatch, caps, _ok_response())
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    persona = _make_persona(tmp_path / "alice")
+    (tmp_path / "a.wav").write_bytes(b"IGNORED")
+
+    code = speak.main(
+        ["Hello", "--server", "http://x", "--persona-dir", str(persona),
+         "--ref-audio", str(tmp_path / "a.wav"),
+         "--ref-audio-transcript", str(tmp_path / "a.txt")]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "Warning: --ref-audio ignored because --persona-dir was given." in out
+    assert "Warning: --ref-audio-transcript ignored because --persona-dir was given." in out
+
+
+# ---------------------------------------------------------------------------
+# run_aplay: temp-file lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_run_aplay_withTempfileCreationFailure_propagatesOriginalError(monkeypatch):
+    # GIVEN temp-file creation itself fails (e.g. temp filesystem full)
+    def boom(*_args, **_kwargs):
+        raise OSError("temp filesystem full")
+
+    monkeypatch.setattr(speak.tempfile, "NamedTemporaryFile", boom)
+
+    # WHEN run_aplay runs
+    # THEN the original OSError propagates — the cleanup path must not raise
+    #      a NameError for an unbound temp file and mask it
+    with pytest.raises(OSError, match="temp filesystem full"):
+        speak.run_aplay(b"WAVDATA")
+
+
+def test_run_aplay_onSuccess_leavesNoTempFileBehind(monkeypatch):
+    seen = {}
+
+    def fake_run(cmd, **_kwargs):
+        seen["path"] = cmd[-1]
+        seen["existed_while_running"] = os.path.exists(cmd[-1])
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(speak.subprocess, "run", fake_run)
+
+    # WHEN run_aplay plays successfully
+    # THEN the file existed while aplay ran and is gone afterwards
+    assert speak.run_aplay(b"WAVDATA") is True
+    assert seen["existed_while_running"] is True
+    assert os.path.exists(seen["path"]) is False
+
+
+# ---------------------------------------------------------------------------
+# Listing server parameters (--list-server-params)
+# ---------------------------------------------------------------------------
+
+
+def test_main_withListServerParams_printsSummaryAndSkipsSynthesis(monkeypatch, capsys):
+    # GIVEN a real dots.tts capabilities document and spies on all network
+    #      calls
+    caps = _caps("dots_capabilities.json")
+    urls: list[str] = []
+    posted: list[dict] = []
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: (urls.append(url), caps)[1])
+    monkeypatch.setattr(
+        speak, "post_json", lambda url, payload, timeout: posted.append(payload) or {}
+    )
+
+    # WHEN the user asks for the parameter listing (note: no --ref-audio!)
+    code = speak.main(["--server", "http://10.0.0.5:8000/", "--list-server-params"])
+
+    # THEN exit 0, only /capabilities was hit, nothing was POSTed, and the
+    #      summary shows the metadata and the flags this script exposes
+    assert code == 0
+    assert urls == ["http://10.0.0.5:8000/capabilities"]
+    assert posted == []
+    out = capsys.readouterr().out
+    assert "Endpoint:    /synthesize" in out
+    assert "--num-steps" in out
+    assert "--ode-method" in out
+    assert "choices: euler, midpoint, rk4" in out
+    assert "range: 1..64" in out
+    assert "--ref-audio" in out  # file-driven fields shown with their provider flag
+
+
+def test_main_withListServerParamsAndUnknownSchemaVersion_exits1(tmp_path, monkeypatch, capsys):
+    caps = _caps("dots_capabilities.json")
+    caps["schema_version"] = 99
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: caps)
+
+    code = speak.main(["--server", "http://x", "--list-server-params"])
+
+    assert code == 1
+    assert "Server returned unknown schema version 99, expected 2; aborting." in capsys.readouterr().err
+
+
+def test_format_server_params_withReservedParam_marksItIgnored():
+    # GIVEN a server advertising a parameter whose flag is reserved
+    # WHEN the summary is rendered
+    # THEN the flag is shown but marked as ignored by this script
+    caps = {
+        "engine": "x",
+        "model": "m",
+        "device": "cpu",
+        "sample_rate": 24000,
+        "watermarked": False,
+        "endpoint": "/synthesize",
+        "languages": None,
+        "reference_audio": None,
+        "parameters": [
+            {"name": "timeout", "type": "integer", "required": False, "default": 5, "description": ""}
+        ],
+    }
+    text = speak.format_server_params(caps)
+    assert "--timeout" in text
+    assert "[ignored by this script: reserved flag name]" in text
+
+
+# ---------------------------------------------------------------------------
+# save_or_play: save and play are mutually exclusive (spec: 'Output')
+# ---------------------------------------------------------------------------
+
+
+def test_save_or_play_withOutputFile_writesFileWithoutCallingAplay(tmp_path, monkeypatch):
+    # GIVEN the silent path: an output file is requested
+    aplay_calls = _aplay_spy(monkeypatch)
+    out_file = tmp_path / "o.wav"
+
+    # WHEN save_or_play runs
+    speak.save_or_play(b"WAVDATA", str(out_file))
+
+    # THEN the file is written and aplay is never invoked
+    assert out_file.read_bytes() == b"WAVDATA"
+    assert aplay_calls == []
+
+
+def test_save_or_play_withoutOutputFile_playsAudio(monkeypatch):
+    # GIVEN the play path: no output file
+    aplay_calls = _aplay_spy(monkeypatch)
+
+    # WHEN save_or_play runs
+    speak.save_or_play(b"WAVDATA", None)
+
+    # THEN the audio is handed to aplay exactly once
+    assert aplay_calls == [b"WAVDATA"]
+
+
+def test_save_or_play_withoutOutputFile_whenAplayFails_warnsAndReturnsNormally(monkeypatch, capsys):
+    # GIVEN the play path and aplay that exits non-zero
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: False)
+
+    # WHEN save_or_play runs, THEN the failure is a warning, not an exception
+    speak.save_or_play(b"WAVDATA", None)
+
+    assert "Warning: aplay returned a non-zero exit code" in capsys.readouterr().out
+
+
+def test_save_or_play_withExistingFileAndDeclinedOverwrite_discardsWithoutCallingAplay(tmp_path, monkeypatch):
+    # GIVEN an existing output file and a "n" answer at the overwrite prompt
+    aplay_calls = _aplay_spy(monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda *a: "n")
+    out_file = tmp_path / "o.wav"
+    out_file.write_bytes(b"OLD")
+
+    # WHEN save_or_play runs
+    speak.save_or_play(b"NEW", str(out_file))
+
+    # THEN the old file is untouched, nothing is written, nothing is played
+    assert out_file.read_bytes() == b"OLD"
+    assert aplay_calls == []
+
+
+def test_save_or_play_withExistingFileAndEofAtPrompt_discardsWithoutCallingAplay(tmp_path, monkeypatch):
+    # GIVEN an existing output file and stdin at EOF (piped, non-interactive):
+    #      the prompt must be treated as a decline
+    aplay_calls = _aplay_spy(monkeypatch)
+
+    def eof(*_args):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", eof)
+    out_file = tmp_path / "o.wav"
+    out_file.write_bytes(b"OLD")
+
+    speak.save_or_play(b"NEW", str(out_file))
+
+    assert out_file.read_bytes() == b"OLD"
+    assert aplay_calls == []
+
+
+def test_save_or_play_withUnwritablePath_raisesSpeakError(tmp_path, monkeypatch):
+    # GIVEN an output path whose parent directory does not exist
+    aplay_calls = _aplay_spy(monkeypatch)
+
+    # WHEN save_or_play tries to write it, THEN a SpeakError (exit-1 family)
+    #      is raised and aplay was still never invoked
+    with pytest.raises(speak.SpeakError, match=r"Could not write output file"):
+        speak.save_or_play(b"WAVDATA", str(tmp_path / "does-not-exist" / "o.wav"))
+    assert aplay_calls == []


### PR DESCRIPTION
This PR addresses issue #5 by introducing a `speak.py` command-line testing tool, based loosely on the old hard-coded script from the ai-playground, but updated to include full server input parameter discoverability. The script can be used to interact with any running tts-serve instance, with full support for any input parameter supported by that server.

Tests and specification document included.