### PR TITLE
Issue #7 - speak.py: allow env var overrides

### DIFF
--- a/docs/03-speak-script.md
+++ b/docs/03-speak-script.md
@@ -69,7 +69,7 @@ Use `argparse` for command-line argument handling.
 
 The new script's only known-in-advance parameters (`parse_known_args()`):
 
-- `--server`: (required! no default) The server URL (example: `http://10.0.0.5:8000`)
+- `--server`: (optional, but see Environment Variables section) The server URL (example: `http://10.0.0.5:8000`)
   **Note**: the old script required the full URL, with endpoint (example: `http://10.0.0.5:8000/synthesize`).
   This new script requires just the server name/IP and port. The endpoint is discovered from `/capabilities`.
 - `text` (required positional argument): any text to be synthesized.
@@ -172,14 +172,17 @@ the supplied reference text with a warning ("Reference text ignored as this serv
 It is always an error to omit `--ref-audio` (or `--persona-dir`, if `--ref-audio` is not specified).
 ALL tts-serve implementation scripts require `audio_base64`. So, even though both `--ref-audio`
 and `--persona-dir` are marked as optional arguments, at least one of them must be specified!
-Exit with status 1 and message "You must supply reference audio or a persona directory!"
+Exit with status 2 and message "You must supply reference audio or a persona directory!"
+Note that `--persona-dir` can also be specified by an environment variable. See the Environment
+Variables section for details.
 
 ## Persona Directory
 
-Instead of `--ref-audio` and `--ref-audio-transcript`, the user can supply `--persona-dir`,
-pointing to any directory. This directory should contain `ref.wav` representing the reference
-audio, and `ref.txt` representing the reference transcript. It is an error if either file is missing,
-or if the given directory does not exist or can't be read.
+Instead of `--ref-audio` and `--ref-audio-transcript`, the user can supply `--persona-dir`
+(or the `TTS_SPEAK_PERSONA_DIR` env var), pointing to any directory. This directory should
+contain `ref.wav` representing the reference audio, and `ref.txt` representing the reference
+transcript. It is an error if either file is missing, or if the given directory does not
+exist or can't be read.
 
 If both `--ref-audio` and `--persona-dir` are given, `--ref-audio` is ignored with a warning.
 
@@ -220,3 +223,88 @@ Normal logging and warnings to stdout, errors to stderr. User can redirect as ne
 `AGENTS.md` in this repo requires a full `python -m pytest tts-engine-common/tests impl/tests`
 after every code change, to ensure all tests are green. That instruction should be updated to
 include the tests for this script in the new `tools` directory.
+
+## Environment variables
+
+### Specifying server
+
+The `--server` command line argument is technically required (we can't discover capabilities
+without a TTS server), but must be marked as optional in argparse, as its value can come
+from two sources:
+
+- the `--server` command line argument itself
+- a `TTS_SPEAK_SERVER` environment variable
+
+At least one of these must be provided. The suggested approach is to check for the environment
+variable first, then allow the command line argument to override it:
+
+```
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--server",
+    required=False,
+    default=os.environ.get("TTS_SPEAK_SERVER"),
+)
+
+args = parser.parse_args()
+
+if args.server is None:
+    parser.error("the following arguments are required: --server")
+```
+
+To make this clear to the user, custom help text should be supplied, rather than relying
+on argparse's auto-generated text. Something like this:
+
+```
+help=(
+    "Server address. Required unless TTS_SPEAK_SERVER env var is set "
+    f"(currently: {os.environ.get('TTS_SPEAK_SERVER', 'not set')}). "
+    "Command-line value takes precedence. Note: supply base URL only. "
+    "The endpoint is discovered from /capabilities."
+),
+```
+
+If both the env var and the command line argument are specified, the command line arg wins.
+If neither is set, exit with code 2 and message: "the following arguments are required: --server"
+
+Note that the `--list-server-params` option should work regardless of whether the server
+is supplied via `--server` or via `TTS_SPEAK_SERVER`, as long as at least one is valid.
+Same precedence order applies: the command line arg wins if both are specified.
+
+**Error precedence**: missing server is reported before missing reference audio / missing text.
+
+### Specifying persona directory
+
+The `--persona-dir` argument will also have an environment variable fallback
+`TTS_SPEAK_PERSONA_DIR`. This env var will **only** apply when `--persona-dir` is not specified.
+The precedence order for this is:
+
+1. `--persona-dir` supersedes both `--ref-audio` and the env var.
+2. `--ref-audio` supersedes the env var, if `--persona-dir` is not specified.
+3. if neither `--persona-dir` nor `--ref-audio` is specified, use the value from
+   the environment variable as though it had been given to `--persona-dir`.
+4. if none of the above are specified, exit with code 2 and message
+   "You must supply reference audio or a persona directory!"
+
+If either env var is set to an empty/blank string, it should be treated as unset.
+
+### Notes for testing
+
+In order to keep the tests hermetic on a dev box that may have the environment variables specified,
+the tests should have an autouse fixture that strips both `TTS_SPEAK_*` env vars.
+
+In previous versions of this specification, `--server` was marked as required, so there are
+currently no explicit tests for missing server (we got it for free from argparse itself).
+Now that it is marked as optional, with custom rules around resolving a value of it,
+there should be new tests to cover these scenarios: neither env var nor command line arg supplied
+(should error), both env var and command line arg supplied (should ignore env var), empty
+env var supplied (should be treated as unset), only env var supplied (should use the env var value),
+only command line arg supplied (should use the command line arg).
+
+The same scenarios should be covered for TTS_SPEAK_PERSONA_DIR: both --persona-dir and the env var
+(use the flag, env var silently ignored); only --ref-audio with the env var set (use --ref-audio,
+env var silently ignored with no warning — this distinguishes an explicit flag from the env-var fallback);
+only the env var (resolved exactly as if given to --persona-dir, including the exit-1 validation errors
+for a bad path); empty env var (treated as unset); and none of --ref-audio, --persona-dir, or the env
+var (exit 2 — note the existing test currently asserts exit 1 and must be updated).
+

--- a/tools/speak.py
+++ b/tools/speak.py
@@ -14,6 +14,10 @@ Usage:
         --persona-dir ./alice --language fr --output-file greeting.wav
     python tools/speak.py --server http://10.0.0.5:8000 --list-server-params
 
+`--server` and `--persona-dir` may also come from the TTS_SPEAK_SERVER and
+TTS_SPEAK_PERSONA_DIR environment variables; an explicit flag always wins,
+and blank values are treated as unset.
+
 Standard library only, on purpose: this must run on any client box, even
 without tts-engine-common (or torch) installed.
 
@@ -67,6 +71,11 @@ _RESERVED_FLAGS = frozenset(
     )
 )
 
+# Environment-variable fallbacks for two flags (spec: 'Environment
+# variables').  Blank values are treated as unset (see _env_or_none).
+SERVER_ENV_VAR = "TTS_SPEAK_SERVER"
+PERSONA_DIR_ENV_VAR = "TTS_SPEAK_PERSONA_DIR"
+
 _PERSONA_AUDIO_NAME = "ref.wav"
 _PERSONA_TRANSCRIPT_NAME = "ref.txt"
 
@@ -118,6 +127,18 @@ def positive_timeout(value: str) -> int:
 def join_url(base: str, path: str) -> str:
     """Join a server base URL and a path, normalizing duplicate slashes."""
     return base.rstrip("/") + "/" + path.lstrip("/")
+
+
+def _env_or_none(name: str) -> str | None:
+    """Read a config env var, treating empty/blank values as unset.
+
+    The spec requires a blank TTS_SPEAK_SERVER to fall through to the exit-2
+    usage error, not to masquerade as a configured value and die later as a
+    baffling 'Failed to connect to server'.  Stripping also absorbs the
+    accidental-trailing-space case that shell exports are famous for.
+    """
+    value = os.environ.get(name, "").strip()
+    return value or None
 
 
 def load_audio_base64(path: str) -> str:
@@ -177,6 +198,26 @@ def resolve_reference_sources(
 def _require_readable_file(path: str, label: str) -> None:
     if not os.path.isfile(path) or not os.access(path, os.R_OK):
         raise SpeakError(f"{label} not found or not readable: {path}")
+
+
+def resolve_persona_dir(
+    explicit_persona_dir: str | None, ref_audio: str | None, env_persona_dir: str | None
+) -> str | None:
+    """Resolve the effective persona directory (spec: 'Specifying persona directory').
+
+    Precedence: explicit --persona-dir, then --ref-audio, then the env var.
+    The env var is only a *fallback* for the "no reference source at all"
+    case — it must never steal a reference the user pointed elsewhere, which
+    is why --ref-audio short-circuits it (silently, per the spec).
+    ``explicit_persona_dir`` is None when the flag was not given; a plain
+    argparse default could not make that distinction, which is why the flag
+    uses SUPPRESS instead.
+    """
+    if explicit_persona_dir is not None:
+        return explicit_persona_dir
+    if ref_audio:
+        return None
+    return env_persona_dir
 
 
 def check_schema_version(capabilities: dict) -> None:
@@ -259,6 +300,10 @@ def post_json(url: str, payload: dict, timeout: int) -> object:
 
 def build_base_parser() -> argparse.ArgumentParser:
     """Stage-1 parser: only the arguments known in advance (spec: 'Proposed new usage')."""
+    # Read the env fallbacks once, at construction time, so the defaults and
+    # the "(currently: ...)" help annotations can never disagree.
+    server_env = _env_or_none(SERVER_ENV_VAR)
+    persona_env = _env_or_none(PERSONA_DIR_ENV_VAR)
     parser = argparse.ArgumentParser(
         prog="speak.py",
         description=(
@@ -284,12 +329,20 @@ def build_base_parser() -> argparse.ArgumentParser:
         default=None,
         help="Text string to synthesize (not needed with --list-server-params)",
     )
+    # required=False on purpose: the value may come from TTS_SPEAK_SERVER.
+    # main() turns "neither source" into an argparse-style usage error
+    # (exit 2) before any network traffic.
     parser.add_argument(
         "--server",
-        required=True,
+        required=False,
+        default=server_env,
         metavar="URL",
-        help="Server base URL, e.g. http://10.0.0.5:8000. "
-        "The synthesis endpoint is discovered via /capabilities.",
+        help=(
+            f"Server address. Required unless {SERVER_ENV_VAR} env var is set "
+            f"(currently: {server_env or 'not set'}). "
+            "Command-line value takes precedence. Note: supply base URL only. "
+            "The endpoint is discovered from /capabilities."
+        ),
     )
     parser.add_argument(
         "--ref-audio",
@@ -305,12 +358,19 @@ def build_base_parser() -> argparse.ArgumentParser:
         help="Path to a text file with the reference audio transcript. "
         "Ignored (with a warning) by engines that do not accept reference_text.",
     )
+    # SUPPRESS (not None): main() must tell an explicit --persona-dir apart
+    # from the TTS_SPEAK_PERSONA_DIR fallback, and a plain default erases
+    # that distinction after parsing.
     parser.add_argument(
         "--persona-dir",
-        default=None,
+        default=argparse.SUPPRESS,
         metavar="DIR",
-        help="Directory containing ref.wav and ref.txt; "
-        "supersedes --ref-audio and --ref-audio-transcript.",
+        help=(
+            "Directory containing ref.wav and ref.txt; "
+            "supersedes --ref-audio and --ref-audio-transcript. "
+            f"When omitted, falls back to the {PERSONA_DIR_ENV_VAR} env var "
+            f"(currently: {persona_env or 'not set'})."
+        ),
     )
     parser.add_argument(
         "--output-file",
@@ -600,12 +660,15 @@ def _fail(message: str) -> int:
 def main(argv: list[str] | None = None) -> int:
     """Run the tool; return the process exit code (0 ok, 1 error; argparse exits 2)."""
     # Stage 1: parse only the arguments known in advance.  Unknown tokens pass
-    # through unvalidated; argparse itself still exits 2 for missing --server
-    # or -h.  The text positional and the reference flags are checked below,
-    # after --list-server-params has had a chance to short-circuit, because
-    # the listing needs neither.
+    # through unvalidated; argparse itself still exits 2 for -h.  The server
+    # (flag or TTS_SPEAK_SERVER) must be resolved here — before even the
+    # --list-server-params short-circuit, which needs the URL — and per the
+    # spec's 'Error precedence' a missing server is reported before any other
+    # usage error.
     parser = build_base_parser()
     args, _unknown = parser.parse_known_args(argv)
+    if args.server is None:
+        parser.error("the following arguments are required: --server")
 
     # Discovery only: no text, no reference audio, no synthesis.
     if args.list_server_params:
@@ -621,8 +684,16 @@ def main(argv: list[str] | None = None) -> int:
     # server errors.
     if args.text is None:
         return _fail("You must supply the text to synthesize!")
-    if not args.ref_audio and not args.persona_dir:
-        return _fail("You must supply reference audio or a persona directory!")
+    # TTS_SPEAK_PERSONA_DIR only applies when --persona-dir was not explicitly
+    # given (argparse.SUPPRESS makes that detectable); the spec then uses it
+    # "as though it had been given to --persona-dir".
+    persona_dir = resolve_persona_dir(
+        getattr(args, "persona_dir", None), args.ref_audio, _env_or_none(PERSONA_DIR_ENV_VAR)
+    )
+    # Exit 2 per spec; routed through argparse so the stderr framing
+    # ("speak.py: error: ...") matches the other usage errors.
+    if not args.ref_audio and not persona_dir:
+        parser.error("You must supply reference audio or a persona directory!")
 
     try:
         capabilities = fetch_capabilities(args.server, args.timeout)
@@ -640,8 +711,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        # persona_dir is the *resolved* value (flag, or env-var fallback), not
+        # the raw stage-2 attribute, which is absent unless the flag was given.
         audio_path, transcript_path = resolve_reference_sources(
-            args.ref_audio, args.ref_audio_transcript, args.persona_dir
+            args.ref_audio, args.ref_audio_transcript, persona_dir
         )
         accepts_reference_text = any(
             p.get("name") == "reference_text" for p in _parameter_specs(capabilities)

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -5,9 +5,27 @@ strategy): these tests must exercise *this repo's* speak.py, so it must win
 over any coincidentally-named installed package.
 """
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 _TOOLS_DIR = str(Path(__file__).resolve().parents[1])
 if _TOOLS_DIR not in sys.path:
     sys.path.insert(0, _TOOLS_DIR)
+
+
+@pytest.fixture(autouse=True)
+def _strip_tts_speak_env(monkeypatch):
+    """Hermeticity: strip ambient TTS_SPEAK_* variables from every test.
+
+    A dev box may legitimately export TTS_SPEAK_SERVER / TTS_SPEAK_PERSONA_DIR,
+    and an exported value would silently change what several end-to-end tests
+    exercise (e.g. the "no reference audio" error would never fire).  Tests
+    that need a value set it explicitly via monkeypatch.  Stripping by prefix
+    means future TTS_SPEAK_* variables stay hermetic too.
+    """
+    for name in list(os.environ):
+        if name.startswith("TTS_SPEAK_"):
+            monkeypatch.delenv(name, raising=False)

--- a/tools/tests/test_speak.py
+++ b/tools/tests/test_speak.py
@@ -105,12 +105,37 @@ def test_load_transcript_withMessyWhitespace_collapsesToSingleSpaces(tmp_path):
 def test_load_transcript_withNonUtf8File_raisesSpeakError(tmp_path):
     path = tmp_path / "ref.txt"
     path.write_bytes(b"\xff\xfe\x00binary")
-    with pytest.raises(speak.SpeakError, match="could not be read as UTF-8"):
+    with pytest.raises(speak.SpeakError, match=r"could not be read as UTF-8"):
         speak.load_transcript(str(path))
 
 
+def test_env_or_none_withUnsetVariable_returnsNone():
+    # GIVEN TTS_SPEAK_SERVER unset (the conftest fixture guarantees this)
+    # WHEN read via _env_or_none
+    # THEN it yields None, the "unset" signal the callers check for
+    assert speak._env_or_none(speak.SERVER_ENV_VAR) is None
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_env_or_none_withBlankVariable_returnsNone(monkeypatch, value):
+    # GIVEN the variable set to an empty or whitespace-only string
+    # WHEN read
+    # THEN it is treated as unset (spec: blank values must not masquerade as
+    #      a configured value and die later as 'Failed to connect')
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, value)
+    assert speak._env_or_none(speak.SERVER_ENV_VAR) is None
+
+
+def test_env_or_none_withValue_stripsSurroundingWhitespace(monkeypatch):
+    # GIVEN the variable set to a value with accidental padding
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "  http://10.0.0.5:8000  ")
+    # WHEN read
+    # THEN the value comes back stripped
+    assert speak._env_or_none(speak.SERVER_ENV_VAR) == "http://10.0.0.5:8000"
+
+
 # ---------------------------------------------------------------------------
-# Stage-1 parser: --timeout
+# Stage-1 parser: --timeout, --server env-var fallback
 # ---------------------------------------------------------------------------
 
 
@@ -135,6 +160,49 @@ def test_build_base_parser_withValidTimeout_parsesIt():
         ["Hi", "--server", "http://x", "--ref-audio", "a.wav", "--timeout", "30"]
     )
     assert args.timeout == 30
+
+
+def test_build_base_parser_withoutServerFlag_defaultsToEnvVar(monkeypatch):
+    # GIVEN TTS_SPEAK_SERVER set and no --server on the command line
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "http://env:8000")
+    parser = speak.build_base_parser()
+
+    # WHEN stage-1 parsing runs
+    # THEN the env var value becomes the argument's value
+    args, _ = parser.parse_known_args(["Hello"])
+    assert args.server == "http://env:8000"
+
+
+def test_build_base_parser_withServerFlagAndEnvVar_flagWins(monkeypatch):
+    # GIVEN both the env var and an explicit --server
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "http://env:8000")
+    parser = speak.build_base_parser()
+
+    # WHEN the command line supplies --server
+    # THEN the command line wins (spec: "the command line arg wins")
+    args, _ = parser.parse_known_args(["Hello", "--server", "http://flag:8000"])
+    assert args.server == "http://flag:8000"
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_annotation"),
+    [("http://10.0.0.5:8000", "http://10.0.0.5:8000"), ("   ", "not set")],
+)
+def test_build_base_parser_withServerEnvVar_helpShowsCurrentValue(
+    monkeypatch, capsys, env_value, expected_annotation
+):
+    # GIVEN the env var set (or blank, which the spec treats as unset)
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, env_value)
+    parser = speak.build_base_parser()
+
+    # WHEN --help is rendered
+    # THEN the custom help names the variable and shows its current value
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["--help"])
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "TTS_SPEAK_SERVER" in out
+    assert expected_annotation in out
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +459,35 @@ def test_build_payload_withoutTranscript_omitsReferenceText():
 # ---------------------------------------------------------------------------
 
 
+def test_resolve_persona_dir_withExplicitFlag_ignoresRefAudioAndEnvVar():
+    # GIVEN --persona-dir explicitly given, plus --ref-audio and the env var
+    # WHEN resolved
+    # THEN the flag wins (spec precedence rule 1)
+    assert speak.resolve_persona_dir("/flag", "/ref.wav", "/env") == "/flag"
+
+
+def test_resolve_persona_dir_withRefAudioOnly_ignoresEnvVar():
+    # GIVEN no explicit --persona-dir, but --ref-audio and the env var
+    # WHEN resolved
+    # THEN no persona dir is used and the env var is silently ignored
+    #      (spec rule 2 — the case a naive argparse default gets wrong)
+    assert speak.resolve_persona_dir(None, "/ref.wav", "/env") is None
+
+
+def test_resolve_persona_dir_withOnlyEnvVar_returnsIt():
+    # GIVEN neither reference flag, but the env var is set
+    # WHEN resolved
+    # THEN it is used "as though it had been given to --persona-dir" (rule 3)
+    assert speak.resolve_persona_dir(None, None, "/env") == "/env"
+
+
+def test_resolve_persona_dir_withNoSourceAtAll_returnsNone():
+    # GIVEN nothing from flag or env var
+    # WHEN resolved
+    # THEN None, so the caller can raise the spec's exit-2 usage error
+    assert speak.resolve_persona_dir(None, None, None) is None
+
+
 def _make_persona(directory: Path, audio: bytes = b"WAV", transcript: str = "ref words") -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     (directory / "ref.wav").write_bytes(audio)
@@ -575,16 +672,18 @@ def test_main_withTranscriptOnServerWithReferenceText_sendsCollapsedText(tmp_pat
     assert seen["reference_text"] == "words here"
 
 
-def test_main_withNoReferenceAudioAtAll_exits1BeforeAnyNetworkCall(monkeypatch, capsys):
-    # GIVEN no --ref-audio and no --persona-dir
+def test_main_withNoReferenceAudioAtAll_exits2BeforeAnyNetworkCall(monkeypatch, capsys):
+    # GIVEN no --ref-audio, no --persona-dir, and no TTS_SPEAK_PERSONA_DIR
+    #      (the conftest fixture strips any ambient value)
     called = []
     monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: called.append(url))
 
     # WHEN main runs
-    code = speak.main(["Hello", "--server", "http://x"])
-
-    # THEN it fails locally (exit 1, spec's message) without touching the network
-    assert code == 1
+    # THEN it fails locally (exit 2 per spec, argparse framing) without
+    #      touching the network
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello", "--server", "http://x"])
+    assert excinfo.value.code == 2
     assert called == []
     assert "You must supply reference audio or a persona directory!" in capsys.readouterr().err
 
@@ -626,6 +725,139 @@ def test_main_withUnreachableServer_exits1(tmp_path, monkeypatch, capsys):
 
     assert code == 1
     assert "Failed to connect to server" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# End-to-end main(): --server / TTS_SPEAK_SERVER
+# ---------------------------------------------------------------------------
+
+
+def test_main_withNoServerAnywhere_exits2WithArgparseMessage(monkeypatch, capsys):
+    # GIVEN no --server and no TTS_SPEAK_SERVER (fixture strips ambient values)
+    # WHEN main runs
+    # THEN argparse reports the missing requirement (exit 2, spec's message)
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello", "--ref-audio", "a.wav"])
+    assert excinfo.value.code == 2
+    assert "the following arguments are required: --server" in capsys.readouterr().err
+
+
+def test_main_withNoServerAndNoRefAudio_reportsMissingServerFirst(monkeypatch, capsys):
+    # GIVEN text, but neither a server nor any reference source
+    # WHEN main runs
+    # THEN the server error precedes the reference-audio error (spec:
+    #      'Error precedence')
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello"])
+    assert excinfo.value.code == 2
+    assert "the following arguments are required: --server" in capsys.readouterr().err
+
+
+def test_main_withNoServerAndNoText_reportsMissingServerFirst(monkeypatch, capsys):
+    # GIVEN reference audio, but neither a server nor text
+    # WHEN main runs
+    # THEN the server error precedes the missing-text error
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["--ref-audio", "a.wav"])
+    assert excinfo.value.code == 2
+    assert "the following arguments are required: --server" in capsys.readouterr().err
+
+
+def test_main_withBlankServerEnvVar_treatsItAsUnset(monkeypatch, capsys):
+    # GIVEN TTS_SPEAK_SERVER set to whitespace only
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "   ")
+
+    # WHEN main runs with no --server
+    # THEN the blank value is treated as unset: the spec's exit-2 usage error
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello", "--ref-audio", "a.wav"])
+    assert excinfo.value.code == 2
+    assert "the following arguments are required: --server" in capsys.readouterr().err
+
+
+def test_main_withOnlyServerEnvVar_andListServerParams_queriesEnvValue(monkeypatch):
+    # GIVEN the server only via the env var
+    caps = _caps("dots_capabilities.json")
+    urls: list[str] = []
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "http://env.example:8000")
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: (urls.append(url), caps)[1])
+
+    # WHEN the user asks for the parameter listing (no --server on the CLI)
+    # THEN the listing works and queries the env var's URL (spec: listing must
+    #      work with either source)
+    code = speak.main(["--list-server-params"])
+
+    assert code == 0
+    assert urls == ["http://env.example:8000/capabilities"]
+
+
+def test_main_withOnlyServerEnvVar_sendsRequestToEnvValue(tmp_path, monkeypatch):
+    caps = _caps("chatterbox_capabilities.json")
+    seen, urls = {}, []
+    _stub_network(monkeypatch, caps, _ok_response(), seen, urls)
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "http://env.example:8000")
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    # WHEN synthesizing with --server absent from the command line
+    code = speak.main(
+        ["Hello", "--ref-audio", str(tmp_path / "a.wav"), "--output-file", str(tmp_path / "o.wav")]
+    )
+
+    # THEN both requests go to the env var's server
+    assert code == 0
+    assert urls == [
+        "http://env.example:8000/capabilities",
+        "http://env.example:8000/synthesize",
+    ]
+
+
+def test_main_withServerEnvVarAndFlag_prefersFlag(tmp_path, monkeypatch):
+    caps = _caps("chatterbox_capabilities.json")
+    urls: list[str] = []
+    _stub_network(monkeypatch, caps, _ok_response(), {}, urls)
+    monkeypatch.setenv(speak.SERVER_ENV_VAR, "http://env.example:8000")
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    # WHEN both the env var and the command line supply a server
+    code = speak.main(
+        [
+            "Hello",
+            "--server", "http://flag.example:8000",
+            "--ref-audio", str(tmp_path / "a.wav"),
+            "--output-file", str(tmp_path / "o.wav"),
+        ]
+    )
+
+    # THEN the command line wins and the env var's server is never contacted
+    assert code == 0
+    assert urls == [
+        "http://flag.example:8000/capabilities",
+        "http://flag.example:8000/synthesize",
+    ]
+
+
+def test_main_withOnlyServerFlag_usesFlagValue(tmp_path, monkeypatch):
+    # GIVEN no env var (the conftest fixture strips it): the flag is the sole
+    #      source
+    caps = _caps("chatterbox_capabilities.json")
+    urls: list[str] = []
+    _stub_network(monkeypatch, caps, _ok_response(), {}, urls)
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    code = speak.main(
+        [
+            "Hello",
+            "--server", "http://flag.example:8000",
+            "--ref-audio", str(tmp_path / "a.wav"),
+            "--output-file", str(tmp_path / "o.wav"),
+        ]
+    )
+
+    assert code == 0
+    assert urls == [
+        "http://flag.example:8000/capabilities",
+        "http://flag.example:8000/synthesize",
+    ]
 
 
 def test_main_withUnrecognizedEngineArg_exits2(tmp_path, monkeypatch):
@@ -761,6 +993,103 @@ def test_main_withPersonaDirAndIndividualFlags_warnsAboutIgnoredFlags(tmp_path, 
     out = capsys.readouterr().out
     assert "Warning: --ref-audio ignored because --persona-dir was given." in out
     assert "Warning: --ref-audio-transcript ignored because --persona-dir was given." in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end main(): --persona-dir / TTS_SPEAK_PERSONA_DIR
+# ---------------------------------------------------------------------------
+
+
+def test_main_withPersonaDirFlagAndEnvVar_prefersFlag(tmp_path, monkeypatch):
+    # GIVEN both an explicit --persona-dir and TTS_SPEAK_PERSONA_DIR, each
+    #      pointing at a persona with different content
+    caps = _caps("dots_capabilities.json")
+    seen = {}
+    _stub_network(monkeypatch, caps, _ok_response(), seen)
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    flag_persona = _make_persona(tmp_path / "flag", audio=b"FLAG", transcript="flag words")
+    env_persona = _make_persona(tmp_path / "env", audio=b"ENV", transcript="env words")
+    monkeypatch.setenv(speak.PERSONA_DIR_ENV_VAR, str(env_persona))
+
+    # WHEN main runs with the explicit flag
+    # THEN the flag's persona is used and the env var is silently ignored
+    #      (spec rule 1)
+    code = speak.main(["Hello", "--server", "http://x", "--persona-dir", str(flag_persona)])
+
+    assert code == 0
+    assert base64.b64decode(seen["audio_base64"]) == b"FLAG"
+    assert seen["reference_text"] == "flag words"
+
+
+def test_main_withRefAudioAndPersonaEnvVar_usesRefAudioWithoutWarning(tmp_path, monkeypatch, capsys):
+    # GIVEN TTS_SPEAK_PERSONA_DIR set, but the user supplied only --ref-audio
+    caps = _caps("chatterbox_capabilities.json")  # no reference_text: simple payload
+    seen = {}
+    _stub_network(monkeypatch, caps, _ok_response(), seen)
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    env_persona = _make_persona(tmp_path / "env", audio=b"ENV")
+    monkeypatch.setenv(speak.PERSONA_DIR_ENV_VAR, str(env_persona))
+    (tmp_path / "a.wav").write_bytes(b"REF")
+
+    # WHEN main runs
+    # THEN --ref-audio is used and the env var is ignored *silently* — no
+    #      "ignored because --persona-dir was given" warning (spec rule 2;
+    #      this is the case a naive argparse default gets wrong)
+    code = speak.main(["Hello", "--server", "http://x", "--ref-audio", str(tmp_path / "a.wav")])
+
+    assert code == 0
+    assert base64.b64decode(seen["audio_base64"]) == b"REF"
+    assert "ignored" not in capsys.readouterr().out
+
+
+def test_main_withOnlyPersonaEnvVar_resolvesLikeExplicitFlag(tmp_path, monkeypatch):
+    # GIVEN TTS_SPEAK_PERSONA_DIR set and no reference flags at all
+    caps = _caps("dots_capabilities.json")  # advertises reference_text
+    seen = {}
+    _stub_network(monkeypatch, caps, _ok_response(), seen)
+    monkeypatch.setattr(speak, "run_aplay", lambda audio: True)
+    persona = _make_persona(tmp_path / "env", audio=b"PERSONA", transcript="env words")
+    monkeypatch.setenv(speak.PERSONA_DIR_ENV_VAR, str(persona))
+
+    # WHEN main runs
+    # THEN the persona dir is resolved exactly as if the flag had been given
+    #      (spec rule 3)
+    code = speak.main(["Hello", "--server", "http://x"])
+
+    assert code == 0
+    assert base64.b64decode(seen["audio_base64"]) == b"PERSONA"
+    assert seen["reference_text"] == "env words"
+
+
+def test_main_withPersonaEnvVarPointingAtMissingDir_exits1LikeExplicitFlag(
+    tmp_path, monkeypatch, capsys
+):
+    # GIVEN TTS_SPEAK_PERSONA_DIR naming a directory that does not exist
+    caps = _caps("dots_capabilities.json")
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: caps)
+    monkeypatch.setenv(speak.PERSONA_DIR_ENV_VAR, str(tmp_path / "nope"))
+
+    # WHEN main runs with no reference flags
+    # THEN the env-var persona goes through the same validation as an
+    #      explicit --persona-dir: exit 1, same message (spec rule 3,
+    #      "as though it had been given")
+    code = speak.main(["Hello", "--server", "http://x"])
+
+    assert code == 1
+    assert "Persona directory does not exist or is not a directory" in capsys.readouterr().err
+
+
+def test_main_withBlankPersonaEnvVar_treatsItAsUnset(tmp_path, monkeypatch, capsys):
+    # GIVEN TTS_SPEAK_PERSONA_DIR set to whitespace only and no reference flags
+    monkeypatch.setenv(speak.PERSONA_DIR_ENV_VAR, "   ")
+    monkeypatch.setattr(speak, "fetch_json", lambda url, timeout: None)
+
+    # WHEN main runs
+    # THEN the blank value is treated as unset: the spec's exit-2 usage error
+    with pytest.raises(SystemExit) as excinfo:
+        speak.main(["Hello", "--server", "http://x"])
+    assert excinfo.value.code == 2
+    assert "You must supply reference audio or a persona directory!" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #7 by modifying the `speak.py` script to allow environment variables to override certain arguments:

- `TTS_SPEAK_SERVER` can be used in place of `--server`
- `TTS_SPEAK_PERSONA_DIR` can be used in place of `--persona-dir`

If both the env var and its matching command line argument are supplied, the command line arg wins.

Updated tests as needed.

Updated the specification doc to describe the new expected behaviour.