### PR TITLE
Issue #9 minor formatting cleanup in speak.py

### DIFF
--- a/docs/03-speak-script.md
+++ b/docs/03-speak-script.md
@@ -208,6 +208,19 @@ All `tts-serve` implementation scripts return `seed`, `time_used`, and `rtf`. Th
 be logged regardless of the output destination of the audio. Log this before attempting
 to play/save the audio! Otherwise, it may get skipped if audio output or save fails.
 
+The stats should be logged in a human-readable block: a `Generation stats:` header line,
+followed by one indented line per stat. `time_used` and `rtf` are rounded to two decimal
+places (with the `s` unit suffix on `time_used`); the seed is an integer and is shown
+whole. Absent or non-numeric values are shown as `null` / as-is rather than crashing the
+run after a successful synthesis. For example:
+
+```
+Generation stats:
+  seed: 42
+  time_used: 3.69s
+  rtf: 0.12
+```
+
 ## Logging
 
 Normal logging and warnings to stdout, errors to stderr. User can redirect as needed.

--- a/tools/speak.py
+++ b/tools/speak.py
@@ -569,12 +569,43 @@ def save_or_play(audio_bytes: bytes, output_file: str | None) -> None:
 
 
 def _format_stats(response: dict) -> str:
-    rtf = response.get("rtf")
-    return (
-        f"seed={response.get('seed')} "
-        f"time_used={response.get('time_used')}s "
-        f"rtf={'null' if rtf is None else rtf}"
+    """Render the synthesis response as a human-readable stats block.
+
+    One stat per indented line under a header; the continuous values
+    (time_used, rtf) are rounded to two decimal places.  The seed is an
+    integer and is shown whole rather than as 7.00 — the one-line
+    "seed=7 time_used=1.5s rtf=0.3" form this replaces was
+    machine-readable at best, which is precisely the point.
+    """
+    return "\n".join(
+        (
+            "Generation stats:",
+            f"  seed: {_format_seed(response.get('seed'))}",
+            f"  time_used: {_format_stat_value(response.get('time_used'), unit='s')}",
+            f"  rtf: {_format_stat_value(response.get('rtf'))}",
+        )
     )
+
+
+def _format_seed(value: object) -> str:
+    """Render the seed whole ('null' when the response omits it)."""
+    return "null" if value is None else str(value)
+
+
+def _format_stat_value(value: object, unit: str = "") -> str:
+    """Round a numeric stat to two decimals, appending an optional unit.
+
+    The unit is only attached to real numbers, so an absent time_used
+    renders as "null", not "nulls".  A value that is not numeric (a broken
+    server) is shown as-is: the synthesis already succeeded, so the stats
+    line must not crash the run.
+    """
+    if value is None:
+        return "null"
+    try:
+        return f"{float(value):.2f}{unit}"
+    except (TypeError, ValueError):
+        return str(value)
 
 
 def _format_number(value: object) -> str:

--- a/tools/tests/test_speak.py
+++ b/tools/tests/test_speak.py
@@ -271,6 +271,79 @@ def test_validate_response_withValidBody_returnsBody():
 
 
 # ---------------------------------------------------------------------------
+# Stats formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_stats_withFullResponse_rendersHeaderAndOneStatPerLine():
+    # GIVEN a well-formed synthesis response
+    response = {"audio_base64": "AAAA", "seed": 42, "time_used": 3.689, "rtf": 0.1234}
+
+    # WHEN formatted for display
+    # THEN each stat gets its own indented line under a header, and the
+    #      continuous values are rounded to two decimal places
+    assert speak._format_stats(response) == (
+        "Generation stats:\n"
+        "  seed: 42\n"
+        "  time_used: 3.69s\n"
+        "  rtf: 0.12"
+    )
+
+
+def test_format_stats_withWholeSeconds_keepsTwoDecimals():
+    # GIVEN a response whose time_used is a whole number of seconds
+    response = {"seed": 7, "time_used": 3.0, "rtf": 0.5}
+
+    # WHEN formatted
+    # THEN time_used still carries the two-decimal contract (3.00s, not 3s)
+    assert speak._format_stats(response) == (
+        "Generation stats:\n"
+        "  seed: 7\n"
+        "  time_used: 3.00s\n"
+        "  rtf: 0.50"
+    )
+
+
+def test_format_stats_withNullRtf_rendersNull():
+    # GIVEN a response whose rtf is null (the response model allows it:
+    #      zero-length audio)
+    response = {"seed": 7, "time_used": 1.0, "rtf": None}
+
+    # WHEN formatted
+    # THEN rtf is shown as "null" — not "None", not "nulls", not a number
+    assert speak._format_stats(response) == (
+        "Generation stats:\n"
+        "  seed: 7\n"
+        "  time_used: 1.00s\n"
+        "  rtf: null"
+    )
+
+
+def test_format_stats_withAbsentStats_rendersNullsWithoutRaising():
+    # GIVEN a response missing the stats fields entirely (a broken server)
+    response = {"audio_base64": "AAAA"}
+
+    # WHEN formatted
+    # THEN the formatter degrades to "null" lines instead of crashing a run
+    #      that already succeeded
+    assert speak._format_stats(response) == (
+        "Generation stats:\n"
+        "  seed: null\n"
+        "  time_used: null\n"
+        "  rtf: null"
+    )
+
+
+def test_format_stats_withNonNumericStat_showsTheValueAsIs():
+    # GIVEN a response whose time_used is not a number (a broken server)
+    response = {"seed": 7, "time_used": "a long time", "rtf": 0.5}
+
+    # WHEN formatted
+    # THEN the value is shown as-is rather than raising in the formatter
+    assert "  time_used: a long time" in speak._format_stats(response)
+
+
+# ---------------------------------------------------------------------------
 # Capabilities -> argparse mapping (stage 2)
 # ---------------------------------------------------------------------------
 
@@ -614,9 +687,14 @@ def test_main_happyPath_savesFileLogsStatsAndReturnsZero(tmp_path, monkeypatch, 
         "http://10.0.0.5:8000/synthesize",
     ]
     out = capsys.readouterr().out
-    assert "seed=7" in out
-    assert "time_used=1.5s" in out
-    assert "rtf=0.3" in out
+    # Stats are a human-readable block: a header, one stat per indented line,
+    # and two-decimal rounding for the continuous values (spec: 'Output')
+    assert (
+        "Generation stats:\n"
+        "  seed: 7\n"
+        "  time_used: 1.50s\n"
+        "  rtf: 0.30\n"
+    ) in out
     assert "Saved audio to" in out
 
 
@@ -916,7 +994,9 @@ def test_main_whenAplayMissing_exits1AfterLoggingStats(tmp_path, monkeypatch, ca
 
     captured = capsys.readouterr()
     assert code == 1
-    assert "seed=7" in captured.out  # stats logged before the playback attempt failed
+    # stats (header and per-stat lines) logged before the playback attempt failed
+    assert "Generation stats:" in captured.out
+    assert "  seed: 7" in captured.out
     assert "'aplay' not found" in captured.err
 
 


### PR DESCRIPTION
This PR addresses issue #9 by cleaning up the formatting in generation stats output. The previous behavior was very machine-readable, but not user-friendly. The new approach is to output a readable block of text with decimal values rounded to at most two places.

Added tests and updated the spec doc to reflect this.

Closes #9 