### PR TITLE
Issue #15 - change default port from 8000 to 7500

### DIFF
--- a/.agents/skills/new-tts-engine/SKILL.md
+++ b/.agents/skills/new-tts-engine/SKILL.md
@@ -69,7 +69,7 @@ Follow the section layout of `server_chatterbox.py` exactly:
     demands a file path. UUID-named files get per-request cleanup, but if the engine caches
     by file path (faster-qwen3-tts pattern), name the file by content hash and *keep* it —
     deleting a shared name races with concurrent requests. `_numpy_to_wav_bytes`.
-14. **`__main__`** — `uvicorn.run(app, host=<NAME>_HOST (default 0.0.0.0), port=<NAME>_PORT (default 8000))`.
+14. **`__main__`** — `uvicorn.run(app, host=<NAME>_HOST (default 0.0.0.0), port=<NAME>_PORT (default 7500))`.
 
 Env var prefix convention: engine name in caps with underscores (`QWEN3TTS_DEVICE`,
 `DOTS_TTS_MODEL`), plus `*_HOST` / `*_PORT`.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Then use the supplied `speak.py` tool to talk to it:
 
 ```bash
 # What parameters does this server accept?
-python tools/speak.py --server http://localhost:8000 --list-server-params
+python tools/speak.py --server http://localhost:7500 --list-server-params
 
 # Synthesize from reference audio + transcript:
-python tools/speak.py --server http://localhost:8000 \
+python tools/speak.py --server http://localhost:7500 \
   --ref-audio /path/to/reference.wav \
   --ref-audio-transcript /path/to/transcript.txt
 ```
@@ -81,7 +81,7 @@ python tools/speak.py --server http://localhost:8000 \
 You can also use `curl` to quickly verify server health:
 
 ```
-curl http://localhost:8000/health
+curl http://localhost:7500/health
 ```
 
 Every server has:
@@ -148,8 +148,8 @@ In addition to a full suite of unit tests, manual testing is possible via
 REST calls using `curl` or some Postman-like tool against a running `tts-serve` instance:
 
 ```
-curl http://localhost:8000/health # shows basic server information including server type
-curl http://localhost:8000/capabilities # full capabilities list in Json format
+curl http://localhost:7500/health # shows basic server information including server type
+curl http://localhost:7500/capabilities # full capabilities list in Json format
 ```
 
 Actual speech generation is better handled via the `speak.py` script,
@@ -157,7 +157,7 @@ available in the `tools` directory:
 
 ```
 python3 speak.py -h # show general help
-python3 speak-py --server http://localhost:8000 --list-server-params # inspect capabilities
+python3 speak.py --server http://localhost:7500 --list-server-params # inspect capabilities
 ```
 
 ## Documentation

--- a/docs/01-server-generification.md
+++ b/docs/01-server-generification.md
@@ -397,13 +397,13 @@ M1–M3 can proceed in parallel per engine once M1 lands; M4 only needs M2 to st
 
 ```bash
 # 1. Discovery
-curl -s localhost:8000/capabilities | jq .
+curl -s localhost:7500/capabilities | jq .
 #    - schema_version == 1
 #    - parameters[] names match what the UI renders
 #    - reference_audio.languages/etc. correct for this engine
 
 # 2. Strictness
-curl -s -X POST localhost:8000/synthesize -H 'Content-Type: application/json' \
+curl -s -X POST localhost:7500/synthesize -H 'Content-Type: application/json' \
   -d '{"text":"hi","audio_base64":"...","exaggeration":0.9}'   # on a non-chatterbox engine
 #    - expect 422 naming "exaggeration"
 

--- a/docs/03-speak-script.md
+++ b/docs/03-speak-script.md
@@ -60,7 +60,7 @@ Examples:
   speak.py "Bonjour le monde" --language fr --steps 20 --output-file greeting.wav
 
   # Override reference files and server
-  speak.py "Test" --ref-audio my_voice.wav --ref-audio-transcript my_voice.txt --server http://localhost:8000/tts
+  speak.py "Test" --ref-audio my_voice.wav --ref-audio-transcript my_voice.txt --server http://localhost:7500/tts
 ```
 
 ### Proposed new usage
@@ -69,8 +69,8 @@ Use `argparse` for command-line argument handling.
 
 The new script's only known-in-advance parameters (`parse_known_args()`):
 
-- `--server`: (optional, but see Environment Variables section) The server URL (example: `http://10.0.0.5:8000`)
-  **Note**: the old script required the full URL, with endpoint (example: `http://10.0.0.5:8000/synthesize`).
+- `--server`: (optional, but see Environment Variables section) The server URL (example: `http://10.0.0.5:7500`)
+  **Note**: the old script required the full URL, with endpoint (example: `http://10.0.0.5:7500/synthesize`).
   This new script requires just the server name/IP and port. The endpoint is discovered from `/capabilities`.
 - `text` (required positional argument): any text to be synthesized.
   Not needed when `--list-server-params` is given (the listing performs no synthesis).

--- a/impl/README.md
+++ b/impl/README.md
@@ -21,7 +21,7 @@ One FastAPI server per TTS engine. Each server:
 | `server_dotsTTS.py` | dots.tts | 48 kHz | — (the runtime auto-selects CUDA/CPU) | `DOTS_TTS_MODEL` (default `rednote-hilab/dots.tts-soar`) |
 
 All servers also take `*_HOST` (default `0.0.0.0`) and `*_PORT`
-(default `8000`).
+(default `7500`).
 
 ## Running
 

--- a/impl/server_chatterbox.py
+++ b/impl/server_chatterbox.py
@@ -27,7 +27,7 @@ Configuration (environment variables):
     CHATTERBOX_HOST      Bind host for `python server_chatterbox.py`.
                          Default: 0.0.0.0
     CHATTERBOX_PORT      Bind port for `python server_chatterbox.py`.
-                         Default: 8000
+                         Default: 7500
 
 Extra dependencies beyond the chatterbox-tts package:
     pip install fastapi uvicorn loguru soundfile
@@ -35,7 +35,7 @@ Extra dependencies beyond the chatterbox-tts package:
 
 Usage:
     python server_chatterbox.py
-    # or: uvicorn server_chatterbox:app --host 0.0.0.0 --port 8000
+    # or: uvicorn server_chatterbox:app --host 0.0.0.0 --port 7500
 """
 
 from __future__ import annotations
@@ -589,7 +589,7 @@ if __name__ == "__main__":
     import uvicorn
 
     host = os.getenv("CHATTERBOX_HOST", "0.0.0.0")
-    port = int(os.getenv("CHATTERBOX_PORT", "8000"))
+    port = int(os.getenv("CHATTERBOX_PORT", "7500"))
     logger.info("Starting Chatterbox REST API server on %s:%d", host, port)
     # Pass the app object directly instead of a module path string,
     # so this works regardless of how the file is invoked.

--- a/impl/server_dotsTTS.py
+++ b/impl/server_dotsTTS.py
@@ -24,7 +24,7 @@ Configuration (environment variables):
     DOTS_TTS_HOST       Bind host for `python server_dotsTTS.py`.
                         Default: 0.0.0.0
     DOTS_TTS_PORT       Bind port for `python server_dotsTTS.py`.
-                        Default: 8000
+                        Default: 7500
 
 Extra dependencies beyond the dots.tts package:
     pip install fastapi uvicorn loguru soundfile
@@ -32,7 +32,7 @@ Extra dependencies beyond the dots.tts package:
 
 Usage:
     python server_dotsTTS.py
-    # or: uvicorn server_dotsTTS:app --host 0.0.0.0 --port 8000
+    # or: uvicorn server_dotsTTS:app --host 0.0.0.0 --port 7500
 """
 
 from __future__ import annotations
@@ -522,7 +522,7 @@ if __name__ == "__main__":
     import uvicorn
 
     host = os.getenv("DOTS_TTS_HOST", "0.0.0.0")
-    port = int(os.getenv("DOTS_TTS_PORT", "8000"))
+    port = int(os.getenv("DOTS_TTS_PORT", "7500"))
     logger.info("Starting dots.tts REST API server on %s:%d", host, port)
     # Pass the app object directly instead of a module path string,
     # so this works regardless of how the file is invoked.

--- a/impl/server_fasterQwen3TTS.py
+++ b/impl/server_fasterQwen3TTS.py
@@ -42,7 +42,7 @@ Configuration (environment variables):
     FASTER_QWEN3TTS_HOST      Bind host for `python server_fasterQwen3TTS.py`.
                               Default: 0.0.0.0
     FASTER_QWEN3TTS_PORT      Bind port for `python server_fasterQwen3TTS.py`.
-                              Default: 8000
+                              Default: 7500
 
 Extra dependencies beyond the faster-qwen3-tts package:
     pip install fastapi uvicorn loguru soundfile
@@ -50,7 +50,7 @@ Extra dependencies beyond the faster-qwen3-tts package:
 
 Usage:
     python server_fasterQwen3TTS.py
-    # or: uvicorn server_fasterQwen3TTS:app --host 0.0.0.0 --port 8000
+    # or: uvicorn server_fasterQwen3TTS:app --host 0.0.0.0 --port 7500
 """
 
 from __future__ import annotations
@@ -630,7 +630,7 @@ if __name__ == "__main__":
     import uvicorn
 
     host = os.getenv("FASTER_QWEN3TTS_HOST", "0.0.0.0")
-    port = int(os.getenv("FASTER_QWEN3TTS_PORT", "8000"))
+    port = int(os.getenv("FASTER_QWEN3TTS_PORT", "7500"))
     logger.info("Starting faster-qwen3-tts REST API server on %s:%d", host, port)
     # Pass the app object directly instead of a module path string,
     # so this works regardless of how the file is invoked.

--- a/impl/server_omnivoice.py
+++ b/impl/server_omnivoice.py
@@ -23,7 +23,7 @@ Configuration (environment variables):
     OMNIVOICE_HOST       Bind host for `python server_omnivoice.py`.
                          Default: 0.0.0.0
     OMNIVOICE_PORT       Bind port for `python server_omnivoice.py`.
-                         Default: 8000
+                         Default: 7500
 
 Extra dependencies beyond the omnivoice package:
     pip install fastapi uvicorn loguru soundfile
@@ -31,7 +31,7 @@ Extra dependencies beyond the omnivoice package:
 
 Usage:
     python server_omnivoice.py
-    # or: uvicorn server_omnivoice:app --host 0.0.0.0 --port 8000
+    # or: uvicorn server_omnivoice:app --host 0.0.0.0 --port 7500
 """
 
 from __future__ import annotations
@@ -561,7 +561,7 @@ if __name__ == "__main__":
     import uvicorn
 
     host = os.getenv("OMNIVOICE_HOST", "0.0.0.0")
-    port = int(os.getenv("OMNIVOICE_PORT", "8000"))
+    port = int(os.getenv("OMNIVOICE_PORT", "7500"))
     logger.info("Starting OmniVoice REST API server on %s:%d", host, port)
     # Pass the app object directly instead of a module path string,
     # so this works regardless of how the file is invoked.

--- a/impl/server_qwen3TTS.py
+++ b/impl/server_qwen3TTS.py
@@ -24,7 +24,7 @@ Configuration (environment variables):
     QWEN3TTS_HOST       Bind host for `python server_qwen3TTS.py`.
                         Default: 0.0.0.0
     QWEN3TTS_PORT       Bind port for `python server_qwen3TTS.py`.
-                        Default: 8000
+                        Default: 7500
 
 Extra dependencies beyond the qwen-tts package:
     pip install fastapi uvicorn loguru soundfile
@@ -32,7 +32,7 @@ Extra dependencies beyond the qwen-tts package:
 
 Usage:
     python server_qwen3TTS.py
-    # or: uvicorn server_qwen3TTS:app --host 0.0.0.0 --port 8000
+    # or: uvicorn server_qwen3TTS:app --host 0.0.0.0 --port 7500
 """
 
 from __future__ import annotations
@@ -574,7 +574,7 @@ if __name__ == "__main__":
     import uvicorn
 
     host = os.getenv("QWEN3TTS_HOST", "0.0.0.0")
-    port = int(os.getenv("QWEN3TTS_PORT", "8000"))
+    port = int(os.getenv("QWEN3TTS_PORT", "7500"))
     logger.info("Starting Qwen3-TTS REST API server on %s:%d", host, port)
     # Pass the app object directly instead of a module path string,
     # so this works regardless of how the file is invoked.

--- a/tools/speak.py
+++ b/tools/speak.py
@@ -9,10 +9,10 @@ decision D4 (docs/01-server-generification.md): the server's request model is
 the single source of truth, so the CLI can never drift from it.
 
 Usage:
-    python tools/speak.py "Hello, world" --server http://10.0.0.5:8000 --ref-audio my_voice.wav
-    python tools/speak.py "Bonjour le monde" --server http://10.0.0.5:8000 \
+    python tools/speak.py "Hello, world" --server http://10.0.0.5:7500 --ref-audio my_voice.wav
+    python tools/speak.py "Bonjour le monde" --server http://10.0.0.5:7500 \
         --persona-dir ./alice --language fr --output-file greeting.wav
-    python tools/speak.py --server http://10.0.0.5:8000 --list-server-params
+    python tools/speak.py --server http://10.0.0.5:7500 --list-server-params
 
 `--server` and `--persona-dir` may also come from the TTS_SPEAK_SERVER and
 TTS_SPEAK_PERSONA_DIR environment variables; an explicit flag always wins,
@@ -329,11 +329,11 @@ def build_base_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "examples:\n"
-            "  %(prog)s \"Hello, world\" --server http://10.0.0.5:8000 --ref-audio my_voice.wav\n"
-            "  %(prog)s \"Bonjour le monde\" --server http://10.0.0.5:8000 "
+            "  %(prog)s \"Hello, world\" --server http://10.0.0.5:7500 --ref-audio my_voice.wav\n"
+            "  %(prog)s \"Bonjour le monde\" --server http://10.0.0.5:7500 "
             "--persona-dir ./alice --language fr\n"
-            "  %(prog)s \"Test\" --server http://10.0.0.5:8000 --ref-audio v.wav --output-file out.wav\n"
-            "  %(prog)s --server http://10.0.0.5:8000 --list-server-params\n"
+            "  %(prog)s \"Test\" --server http://10.0.0.5:7500 --ref-audio v.wav --output-file out.wav\n"
+            "  %(prog)s --server http://10.0.0.5:7500 --list-server-params\n"
         ),
     )
     # Optional at the argparse level on purpose: --list-server-params needs


### PR DESCRIPTION
This PR addresses issue #15 by changing the default port from 8000 (too commonly used; might cause conflicts in user installs) to 7500 (arbitrary, nice-round-number choice). All constants, examples, and documentation has been updated to use the new port. Left the tests alone since they can use any port without issue.
